### PR TITLE
Untitled

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include CHANGES.txt
 include LICENSE.txt
-include README.txt
+include README.md
 recursive-include examples *.py


### PR DESCRIPTION
Currently, pip install PyHamcrest / easy_install PyHamcrest doesn't work.
It's because source package (PyHamcrest-1.2.tar.gz) doesn't include README.md.
This will fix the problem.

Thank you for your work.
