### PR TITLE
Looks like a merge bug broke tox.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,22 @@ except ImportError:
     use_setuptools()
     from setuptools import setup, find_packages
 
+def local(fname):
+    return os.path.join(os.path.dirname(__file__), fname)
+
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(local(fname)).read()
 
 # On Python 3, we can't "from hamcrest import __version__" (get ImportError),
 # so we extract the variable assignment and execute it ourselves.
-matched = re.match('__version__.*', read(os.path.join('hamcrest', '__init__.py')))
-if matched:
-    exec(matched.group())
+fh = open(local('hamcrest/__init__.py'))
+try:
+    for line in fh:
+        if re.match('__version__.*', line):
+            exec(line)
+finally:
+    if fh:
+        fh.close()
 
 extra_attributes = {}
 if sys.version_info >= (3,):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py25,py26,py27,py31
 
+[testenv]
 commands   = {envbindir}/py.test
 deps       = pytest
 distribute = False


### PR DESCRIPTION
... also, the magic regexp version parsing in setup.py was causing problems, too; it was not handling tox test runs properly. That's fixed and a lot more stable now.
