### PR TITLE
Trove reclassification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ params = dict(
     test_suite = 'hamcrest-unit-test.alltests',
     provides = ['hamcrest'],
     long_description=read('README.md'),
+    install_requires=['distribute'],
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
-envlist = py25,py26,py27,py31,py32,pypy,jython
+envlist = py25,py26,py27,py31,py32,pypy
 
 [testenv]
-commands  = {envbindir}/py.test
+commands  = {envbindir}/py.test hamcrest-unit-test []
 deps      = pytest
 
 [testenv:py31]
 changedir = {envdir}/lib/python3.1/site-packages/PyHamcrest-1.5-py3.1.egg
-commands  = {envbindir}/py.test hamcrest-unit-test
+commands  = {envbindir}/py.test hamcrest-unit-test []
 
 [testenv:py32]
 changedir = {envdir}/lib/python3.2/site-packages/PyHamcrest-1.5-py3.2.egg
-commands  = {envbindir}/py.test hamcrest-unit-test
+commands  = {envbindir}/py.test hamcrest-unit-test []
 
 [testenv:jython]
-commands = {envbindir}/py.test-jython
+commands = {envbindir}/py.test-jython hamcrest-unit-test []


### PR DESCRIPTION
This is a bit extra (and I've uploaded the bdist_egg already); this confirms and tests support for pypy and Python 3.2
