### PR TITLE
Improve "isnumeric" test used inside IsCloseTo

### DIFF
--- a/hamcrest/library/number/iscloseto.py
+++ b/hamcrest/library/number/iscloseto.py
@@ -7,7 +7,16 @@ __license__ = "BSD, see License.txt"
 
 
 def isnumeric(value):
-    return isinstance(value, (int, long, float))
+    """Confirm that 'value' can be treated numerically; duck-test accordingly
+    """
+    try:
+        _ = (fabs(value) + 0 - 0) * 1
+        return True
+    except ArithmeticError:
+        return True
+    except:
+        return False
+    return False
 
 
 class IsCloseTo(BaseMatcher):


### PR DESCRIPTION
The current test for "isnumeric" is extremely restrictive, passing only if "value" is an explicit instance of int/float/long.

The test would fail incorrectly for (amongst other numeric types) reasonable numpy ints/float values as well as decimal.Decimal values, etc. Better to duck-check; if an object doesn't throw on math.fabs (which will be used in the actual test) and it appears to support basic math operators, it should be considered numeric for the purposes of this test.

Additionally, failing the duck-type with an ArithmeticError (while I can't actually see any obvious potential for this) would still indicate the value is numeric, so it should be allowed to fail at a later stage, but should not fail the "isnumeric" test.
