### PR TITLE
Make the has_properties matcher importable

### DIFF
--- a/hamcrest/library/__init__.py
+++ b/hamcrest/library/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     'less_than_or_equal_to',
     'has_length',
     'has_property',
+    'has_properties',
     'has_string',
     'equal_to_ignoring_case',
     'equal_to_ignoring_whitespace',


### PR DESCRIPTION
The new `has_properties` matcher was not imported when `from hamcrest import *`, now it is ;)
