### PR TITLE
Corrected export of string_contains_in_order and associated test

### DIFF
--- a/hamcrest/library/__init__.py
+++ b/hamcrest/library/__init__.py
@@ -37,4 +37,5 @@ __all__ = [
     'contains_string',
     'ends_with',
     'starts_with',
+    'string_contains_in_order',
 ]

--- a/hamcrest/library/text/__init__.py
+++ b/hamcrest/library/text/__init__.py
@@ -5,6 +5,7 @@ from isequal_ignoring_whitespace import equal_to_ignoring_whitespace
 from stringcontains import contains_string
 from stringendswith import ends_with
 from stringstartswith import starts_with
+from stringcontainsinorder import string_contains_in_order
 
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"

--- a/hamcrest_unit_test/text/stringcontainsinorder_test.py
+++ b/hamcrest_unit_test/text/stringcontainsinorder_test.py
@@ -3,7 +3,7 @@ if __name__ == '__main__':
     sys.path.insert(0, '..')
     sys.path.insert(0, '../..')
 
-from hamcrest.library.text.stringcontainsinorder import *
+from hamcrest.library.text import string_contains_in_order
 
 from hamcrest.core.string_description import StringDescription
 from hamcrest_unit_test.matcher_test import MatcherTest


### PR DESCRIPTION
The factory method _string_contains_in_order_ was not correctly exported, but its test imported the method directly, and so was incorrectly passing.
