### PR TITLE
patch for issue #32, matches_regexp not exported 

### DIFF
--- a/hamcrest/library/__init__.py
+++ b/hamcrest/library/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     'contains',
     'only_contains',
     'match_equality',
+    'matches_regexp',
     'close_to',
     'greater_than',
     'greater_than_or_equal_to',

--- a/hamcrest/library/text/__init__.py
+++ b/hamcrest/library/text/__init__.py
@@ -5,6 +5,7 @@ from isequal_ignoring_whitespace import equal_to_ignoring_whitespace
 from stringcontains import contains_string
 from stringendswith import ends_with
 from stringstartswith import starts_with
+from stringmatches import matches_regexp
 
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"


### PR DESCRIPTION
Updated the two __init__.py files necessary to have matches_regexp get imported when one does "from hamcrest import *"
