### PR TITLE
Fix mismatch description of containing_inanyorder

### DIFF
--- a/hamcrest/library/collection/issequence_containinginanyorder.py
+++ b/hamcrest/library/collection/issequence_containinginanyorder.py
@@ -9,7 +9,7 @@ __license__ = "BSD, see License.txt"
 
 class MatchInAnyOrder(object):
     def __init__(self, matchers, mismatch_description):
-        self.matchers = matchers
+        self.matchers = matchers[:]
         self.mismatch_description = mismatch_description
 
     def matches(self, item):
@@ -34,12 +34,11 @@ class MatchInAnyOrder(object):
         return True
 
     def ismatched(self, item):
-        index = 0
-        for matcher in self.matchers:
+        for index, matcher in enumerate(self.matchers):
             if matcher.matches(item):
                 del self.matchers[index]
                 return True
-            index += 1
+
         if self.mismatch_description:
             self.mismatch_description.append_text('not matched: ')  \
                                      .append_description_of(item)

--- a/hamcrest_unit_test/collection/issequence_containinginanyorder_test.py
+++ b/hamcrest_unit_test/collection/issequence_containinginanyorder_test.py
@@ -72,6 +72,12 @@ class IsSequenceContainingInAnyOrderBase(object):
     def testDescribeMismatchOfNonSequence(self):
         self.assert_describe_mismatch("was <3>", contains_inanyorder(1,2), 3)
 
+    def testDescribeMismatchAfterMatch(self):
+        matcher = contains_inanyorder(1, 2, 3)
+        matcher.matches(self._sequence(3, 1))
+        self.assert_describe_mismatch('no item matches: <2> in [<3>, <1>]',
+                                      matcher, self._sequence(3, 1))
+
 
 class IsConcreteSequenceContainingInAnyOrderTest(MatcherTest, IsSequenceContainingInAnyOrderBase, SequenceForm):
     pass


### PR DESCRIPTION
The matcher sequence became exhausted after the first iteration causing
items that where expected to be found to be reported as the offending
elements.
