### PR TITLE
Add not_ alias of is_not for better readability of negations

### DIFF
--- a/src/hamcrest/core/core/__init__.py
+++ b/src/hamcrest/core/core/__init__.py
@@ -9,8 +9,7 @@ from hamcrest.core.core.isanything import anything
 from hamcrest.core.core.isequal import equal_to
 from hamcrest.core.core.isinstanceof import instance_of
 from hamcrest.core.core.isnone import none, not_none
-from hamcrest.core.core.isnot import is_not
-not_ = is_not
+from hamcrest.core.core.isnot import is_not, not_
 from hamcrest.core.core.issame import same_instance
 from hamcrest.core.core.raises import calling, raises
 

--- a/src/hamcrest/core/core/isnot.py
+++ b/src/hamcrest/core/core/isnot.py
@@ -43,5 +43,12 @@ def is_not(match):
         assert_that(cheese, is_not(equal_to(smelly)))
         assert_that(cheese, is_not(smelly))
 
+    For better readability a ``not_`` alias is provided:
+
+        assert_that(alist, not_(has_item(item)))
+
     """
     return IsNot(wrap_value_or_type(match))
+
+# alias for better readability of negations
+not_ = is_not


### PR DESCRIPTION
Example:

> > assert_that(alist, is_not(has_item(item)))

can be

> > assert_that(alist, not_(has_item(item)))
