### PR TITLE
Add doc to sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include CHANGES.txt
 include LICENSE.txt
 include README.md
 recursive-include examples *.py
+recursive-include doc *


### PR DESCRIPTION
Hey,

When packaging this for Gentoo I found the doc directory was missing from the sdist provided by PyPi.  This goes ahead and adds it to the manifest so future sdists will contain that directory if docs are desired during the install.
