### PR TITLE
Delete str() method that causing UnicodeEncodeError

### DIFF
--- a/src/hamcrest/core/assert_that.py
+++ b/src/hamcrest/core/assert_that.py
@@ -54,7 +54,7 @@ def _assert_match(actual, matcher, reason):
                    .append_text('\n     but: ')
         matcher.describe_mismatch(actual, description)
         description.append_text('\n')
-        raise AssertionError(str(description))
+        raise AssertionError(description)
 
 
 def _assert_bool(assertion, reason=None):


### PR DESCRIPTION
If 'matcher' mismatching with 'actual' and one of them has non-ascii encoding, then description has the same type. When str() method trying encode 'description' with ASCII codec it causes UnicodeEncodeError. To avoid getting this error and do not worry about converting to a different encoding, it can simply display the string as is.
