### PR TITLE
Provide better mismatch descriptions for `any_of` and `only_contains`

### DIFF
--- a/src/hamcrest/core/core/anyof.py
+++ b/src/hamcrest/core/core/anyof.py
@@ -20,6 +20,12 @@ class AnyOf(BaseMatcher):
     def describe_to(self, description):
         description.append_list('(', ' or ', ')', self.matchers)
 
+    def describe_mismatch(self, item, mismatch_description):
+        for matcher in self.matchers:
+            if not matcher.matches(item):
+                matcher.describe_mismatch(item, mismatch_description)
+                return
+
 
 def any_of(*items):
     """Matches if any of the given matchers evaluate to ``True``.

--- a/src/hamcrest/library/collection/issequence_onlycontaining.py
+++ b/src/hamcrest/library/collection/issequence_onlycontaining.py
@@ -29,6 +29,21 @@ class IsSequenceOnlyContaining(BaseMatcher):
         description.append_text('a sequence containing items matching ')    \
                     .append_description_of(self.matcher)
 
+    def describe_mismatch(self, item, mismatch_description):
+        super(IsSequenceOnlyContaining, self).describe_mismatch(
+            item, mismatch_description)
+        try:
+            sequence = list(item)
+            for seq_item in sequence:
+                if not self.matcher.matches(seq_item):
+                    mismatch_description.append(
+                        ', first sequence item not matching ')
+                    self.matcher.describe_mismatch(
+                        seq_item, mismatch_description)
+                    return
+        except TypeError:
+            pass
+
 
 def only_contains(*items):
     """Matches if each element of sequence satisfies any of the given matchers.

--- a/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
@@ -4,6 +4,7 @@ from hamcrest.library.collection.issequence_onlycontaining import *
 
 from hamcrest.core.core.isequal import equal_to
 from hamcrest.library.number.ordering_comparison import less_than
+from hamcrest.library.object.haslength import has_length
 from hamcrest_unit_test.matcher_test import MatcherTest
 from .quasisequence import QuasiSequence
 from .sequencemixin import SequenceForm, GeneratorForm
@@ -56,7 +57,30 @@ class IsSequenceOnlyContainingTestBase(object):
                                 only_contains(1,2))
 
     def testDescribeMismatch(self):
-        self.assert_describe_mismatch("was 'bad'", only_contains(1,2), 'bad')
+        self.assert_describe_mismatch(
+            "was 'bad', first sequence item not matching was 'b'", 
+            only_contains(1,2), 'bad')
+
+    def testDescribeMismatchDisplayUsedMatchersDescriptionForFirstFailingItem(self):
+        has_length_matcher = has_length(1)
+        has_length_description = 'an object with length of <1>'
+        has_length_mismatch_text = "was 'sdf' with length of <3>"
+
+        self.assert_description(has_length_description, has_length_matcher)
+        self.assert_describe_mismatch(
+            has_length_mismatch_text, has_length_matcher, 'sdf')
+
+        sequence = self._sequence('a', 'sdf')
+        prefix = postfix = ''
+        if repr(sequence)[0] != '<':
+            prefix = '<'
+            postfix = '>'
+        expected_only_contains_failure_text = \
+            "was {prefix}{sequence!r}{postfix}, " \
+            "first sequence item not matching {has_length_mismatch_text}".format(**locals())
+        self.assert_describe_mismatch(
+            expected_only_contains_failure_text,
+            only_contains(has_length_matcher), sequence)
 
     def testDescribeMismatchOfNonSequence(self):
         self.assert_describe_mismatch("was <3>", only_contains(1,2), 3)

--- a/tests/hamcrest_unit_test/core/anyof_test.py
+++ b/tests/hamcrest_unit_test/core/anyof_test.py
@@ -6,6 +6,7 @@ if __name__ == '__main__':
 from hamcrest.core.core.anyof import *
 
 from hamcrest.core.core.isequal import equal_to
+from hamcrest.library.object.haslength import has_length
 from hamcrest_unit_test.matcher_test import MatcherTest
 import unittest
 
@@ -72,6 +73,10 @@ class AnyOfTest(MatcherTest):
 
     def testMismatchDescriptionDescribesFirstFailingMatch(self):
         self.assert_mismatch_description(
+                                "was 'ugly' with length of <4>",
+                                any_of(has_length(1), equal_to('good')),
+                                'ugly')
+        self.assert_mismatch_description(
                                 "was 'ugly'",
                                 any_of(equal_to('bad'), equal_to('good')),
                                 'ugly')
@@ -81,6 +86,10 @@ class AnyOfTest(MatcherTest):
                                 "was 'ugly'",
                                 any_of(equal_to('bad'), equal_to('good')),
                                 'ugly')
+        self.assert_describe_mismatch(
+                                "was 'sdf' with length of <3>",
+                                any_of(has_length(1)),
+                                'sdf')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What problem does this merge request solve?

running 

```
from hamcrest import *

if __name__ == '__main__':
    assert_that(['a'], only_contains(has_length(3)))
```

in `master` reports

```
Traceback (most recent call last):
...
AssertionError:
Expected: a sequence containing items matching (an object with length of <3>)
     but: was <['a']>
```

after the merge request, the error message becomes

```
Traceback (most recent call last):
...
AssertionError:
Expected: a sequence containing items matching (an object with length of <3>)
     but: was <['a']>, first sequence item not matching was 'a' with length of <1>
```

However, this merge request is not perfect.
# Known (Guessed) Problems
- if `sequence` is a stream generator that can only be iterated   once, then `describe_mismatch` will fail trying to iterate it again. 
  I believe it would be safe to encapsulate `list(sequence)` as an instance variable (or hide behind a memoized property) where it could be used from both methods, but the tutorial/docs are pushing in the direction of stateless matcher preferences. Thus not being familiar enough with the architecture and usages of `hamcrest`, I didn't want to do that initially
# Potentatial Improvements
- `prefix`/`postfix` could be handled as TestCase class variables (like a _"Template Method"_)
- `any_of` had the same problem (8f0bcce) as `only_contains` (5a6c990) - not having a proper delegation to the actual matchers to provide the mismatch description. I suspect there can be other (composite)
  matchers that have the same issue.
- now `issequence_onlycontaining_test` is coupled to the `has_length` implementation. Probably there is (should be) a way to have a matcher with test-controllable `describe_foo` values, so there is no need for coupling. Then the initial assertions from `testDescribeMismatchDisplayUsedMatchersDescriptionForFirstFailingItem` could be removed
- there is too much duplication between `describe_mismatch` and `_matches`. However, to resolve that by introducing a `get_first_mismatch` method would need to be an object (can't use `None` due to the need to distinguish between no mismatches and `TypeError` return type cases), and I didn't want to invest in that until I knew that change was welcome
