### PR TITLE
Install deps often needed for building C modules

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,11 @@ RUN apt-get update && \
 
 # install legacy python versions
 RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install \
-    python2.5 python2.6 python2.7 python3.1 python3.2 python3.3 python3.4
+    python2.5-dev python2.6-dev python2.7-dev python3.1-dev python3.2-dev python3.3-dev python3.4-dev
+
+# install other commonly needed libraries for building Python extensions
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install \
+    freetds-dev libffi-dev libicu-dev libldap2-dev libmemcached-dev libxml2-dev libxmlsec1-dev libxslt1-dev
 
 # add Jython installer
 # ADD jython-installer-2.7-b4.jar /tmp/


### PR DESCRIPTION
Adds the various `python<version>-dev` packages and a few other commonly needed ones like `libffi-dev`, `libmemcached-dev`, etc.

Cc: @sudarkoff, @aconrad