### PR TITLE
Eliminate "Directory not empty" errors

### DIFF
--- a/docker/clean-launch.sh
+++ b/docker/clean-launch.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-find /src \( -name __pycache__ -o -name '*.pyc' \) -delete
+find /src -depth \( -name __pycache__ -o -name '*.pyc' \) -print0 | xargs -0 rm -rf
 exec "$@"


### PR DESCRIPTION
e.g.:

    $ docker run -v $(pwd):/src docker_tox tox -e py26,py27,py33,py34
    find: cannot delete `/src/.tox/py26/lib/python2.6/site-packages/cryptography/hazmat/bindings/__pycache__': Directory not empty
    find: cannot delete `/src/.tox/py27/lib/python2.7/site-packages/cryptography/hazmat/bindings/__pycache__': Directory not empty
    find: cannot delete `/src/.tox/py33/lib/python3.3/site-packages/cryptography/hazmat/bindings/__pycache__': Directory not empty
    find: cannot delete `/src/.tox/py34/lib/python3.4/site-packages/cryptography/hazmat/bindings/__pycache__': Directory not empty
    find: cannot delete `/src/.tox/pypy/site-packages/cryptography/hazmat/bindings/__pycache__': Directory not empty

by tweaking the `find` command in `clean-launch.sh` to use `-depth`. I also
made it use `xargs` so that it will be able to accommodate a large number of
`__pycache__` or `*.pyc` directories/files without exceeding shell length
limits.