### PR TITLE
Return result of a deferred call

### DIFF
--- a/src/hamcrest/core/core/raises.py
+++ b/src/hamcrest/core/core/raises.py
@@ -2,7 +2,6 @@ from weakref import ref
 import re
 import sys
 from hamcrest.core.base_matcher import BaseMatcher
-from hamcrest.core.helpers.wrap_matcher import wrap_matcher
 from hamcrest.core.compat import is_callable
 
 __author__ = "Per Fagrell"
@@ -86,7 +85,7 @@ class DeferredCallable(object):
         self.kwargs = {}
 
     def __call__(self):
-        self.func(*self.args, **self.kwargs)
+        return self.func(*self.args, **self.kwargs)
 
     def with_args(self, *args, **kwargs):
         self.args = args

--- a/tests/hamcrest_unit_test/core/raises_test.py
+++ b/tests/hamcrest_unit_test/core/raises_test.py
@@ -5,7 +5,6 @@ if __name__ == '__main__':
 
 from hamcrest.core.core.raises import *
 
-from hamcrest.core.core.isequal import equal_to
 from hamcrest_unit_test.matcher_test import MatcherTest
 import unittest
 
@@ -90,6 +89,10 @@ class CallingTest(unittest.TestCase):
 
         self.assertEqual(method.args, (3, 1, 4))
         self.assertEqual(method.kwargs, {"keyword1": "arg1"})
+
+    def testCallingReturnsFunctionResult(self):
+        returned = calling(sum).with_args((3, 1, 4))()
+        self.assertEqual(returned, 8)
 
 
 class Callable(object):


### PR DESCRIPTION
In my custom matcher based on `Raises` I need a deferred call result to create a meaningful mismatch description (when there was no exception raised). That's why I think that `DeferredCallable.__call__()` should have a `return` statement.
I'm pretty sure that this change will not break anything.
Also I have removed a couple of unused imports.