### PR TITLE
Don't use describe_to of mock objects

### DIFF
--- a/src/hamcrest/core/base_description.py
+++ b/src/hamcrest/core/base_description.py
@@ -9,6 +9,7 @@ import six
 from hamcrest.core.description import Description
 from hamcrest.core.selfdescribingvalue import SelfDescribingValue
 from hamcrest.core.helpers.hasmethod import hasmethod
+from hamcrest.core.helpers.ismock import ismock
 
 class BaseDescription(Description):
     """Base class for all :py:class:`~hamcrest.core.description.Description`
@@ -21,7 +22,7 @@ class BaseDescription(Description):
         return self
 
     def append_description_of(self, value):
-        if hasmethod(value, 'describe_to'):
+        if not ismock(value) and hasmethod(value, 'describe_to'):
             value.describe_to(self)
         elif six.PY3 and isinstance(value, six.text_type):
             self.append(repr(value))

--- a/src/hamcrest/core/helpers/ismock.py
+++ b/src/hamcrest/core/helpers/ismock.py
@@ -1,0 +1,15 @@
+MOCKTYPES = ()
+try:
+    from mock import Mock
+    MOCKTYPES += (Mock,)
+except ImportError:
+    pass
+try:
+    from unittest.mock import Mock
+    MOCKTYPES += (Mock,)
+except ImportError:
+    pass
+
+
+def ismock(obj):
+    return isinstance(obj, MOCKTYPES)

--- a/tests/hamcrest_unit_test/base_description_test.py
+++ b/tests/hamcrest_unit_test/base_description_test.py
@@ -5,6 +5,7 @@ from mock import sentinel, patch
 
 from hamcrest.core.base_description import BaseDescription
 from hamcrest.core.selfdescribing import SelfDescribing
+from hamcrest.core.helpers.ismock import MOCKTYPES
 
 __author__ = "Chris Rose"
 __copyright__ = "Copyright 2015 hamcrest.org"
@@ -54,3 +55,10 @@ def test_append_description_types(desc, described, appended):
 def test_string_in_python_syntax(desc, char, rep):
     desc.append_string_in_python_syntax(char)
     assert ''.join(desc.appended) == "'{0}'".format(rep)
+
+
+@pytest.mark.parametrize("mock", MOCKTYPES)
+def test_describe_mock(desc, mock):
+    m = mock()
+    desc.append_description_of(m)
+    assert ''.join(desc.appended) == str(m)


### PR DESCRIPTION
When using hamcrest together with mocks and asserting that the same mock objects are being passed around the assertion messages produce are bad because hamcrest ends up calling `describe_to` of the mocks which does nothing.
# before

```
>>> from hamcrest import assert_that, equal_to
>>> from unittest.mock import Mock
>>> a,b = Mock(),Mock()
>>> assert_that(a, equal_to(b))
AssertionError: 
Expected: 
     but: was 
```
# after

```
>>> from hamcrest import assert_that, equal_to
>>> from unittest.mock import Mock
>>> a,b = Mock(),Mock()
AssertionError: 
Expected: <Mock id='139861799912056'>
     but: was <Mock id='139861799911832'>
```
