### PR TITLE
setup.py: drop setuptools from runtime requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ params = dict(
     package_dir = {'': 'src'},
     provides=['hamcrest'],
     long_description=read('README.rst'),
-    install_requires=['setuptools', 'six'],
+    install_requires=['six'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
setuptools are not needed to be installed when we are using this
package.

Signed-off-by: Igor Gnatenko ignatenko@redhat.com
