### PR TITLE
Update README.rst: Broken link on documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,7 +310,7 @@ More resources
 * Sources_
 * Hamcrest_
 
-.. _Documentation: http://readthedocs.org/docs/pyhamcrest/en/V1.8.2/
+.. _Documentation: http://pyhamcrest.readthedocs.io/en/release-1.8/
 .. _Package: http://pypi.python.org/pypi/PyHamcrest
 .. _Sources: https://github.com/hamcrest/PyHamcrest
 .. _Hamcrest: http://hamcrest.org


### PR DESCRIPTION
The link http://readthedocs.org/docs/pyhamcrest/en/V1.8.2/
wasn't working, I'm not sure if the link should be constrained
to a release or not, but that was the only link to docs I found
working.