### PR TITLE
Check that arg1 of assert_that is not Matcher

### DIFF
--- a/src/hamcrest/core/assert_that.py
+++ b/src/hamcrest/core/assert_that.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import warnings
 from hamcrest.core.matcher import Matcher
 from hamcrest.core.string_description import StringDescription
 
@@ -43,7 +44,7 @@ def assert_that(arg1, arg2=None, arg3=''):
         _assert_match(actual=arg1, matcher=arg2, reason=arg3)
     else:
         if isinstance(arg1, Matcher):
-            raise TypeError("arg1 should be boolean, but was {}".format(type(arg1)))
+            warnings.warn("arg1 should be boolean, but was {}".format(type(arg1)))
         _assert_bool(assertion=arg1, reason=arg2)
 
 

--- a/src/hamcrest/core/assert_that.py
+++ b/src/hamcrest/core/assert_that.py
@@ -42,6 +42,8 @@ def assert_that(arg1, arg2=None, arg3=''):
     if isinstance(arg2, Matcher):
         _assert_match(actual=arg1, matcher=arg2, reason=arg3)
     else:
+        if isinstance(arg1, Matcher):
+            raise TypeError("arg1 should be boolean, but was {}".format(type(arg1)))
         _assert_bool(assertion=arg1, reason=arg2)
 
 

--- a/tests/hamcrest_unit_test/assert_that_test.py
+++ b/tests/hamcrest_unit_test/assert_that_test.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 from __future__ import with_statement
+import warnings
 from hamcrest.core.assert_that import assert_that
 from hamcrest.core.core.isequal import equal_to
 try:
@@ -70,13 +71,15 @@ class AssertThatTest(unittest.TestCase):
 
         self.assertEqual('Assertion failed', str(e.exception))
 
-    def testRaisesTypeErrorForMatcherAsArg1(self):
+    def testWarnsForMatcherAsArg1(self):
         assert_that(True)
 
-        with self.assertRaises(TypeError) as e:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             assert_that(equal_to(1))
 
-        self.assertTrue(str(e.exception).startswith('arg1 should be boolean'))
+            self.assertEqual(len(w), 1)
+            self.assertTrue("arg1 should be boolean" in str(w[-1].message))
 
 
 if __name__ == "__main__":

--- a/tests/hamcrest_unit_test/assert_that_test.py
+++ b/tests/hamcrest_unit_test/assert_that_test.py
@@ -67,8 +67,16 @@ class AssertThatTest(unittest.TestCase):
 
         with self.assertRaises(AssertionError) as e:
             assert_that(False)
-            
+
         self.assertEqual('Assertion failed', str(e.exception))
+
+    def testRaisesTypeErrorForMatcherAsArg1(self):
+        assert_that(True)
+
+        with self.assertRaises(TypeError) as e:
+            assert_that(equal_to(1))
+
+        self.assertTrue(str(e.exception).startswith('arg1 should be boolean'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This prevents mistakes such as

```py
assert_that(not_(foo))
```

Where `foo` is some boolean expression.  Currently, this would just silently pass regardless of whether `foo` is `True` or `False`.