### PR TITLE
Make only_contains pass for empty list

### DIFF
--- a/src/hamcrest/library/collection/issequence_onlycontaining.py
+++ b/src/hamcrest/library/collection/issequence_onlycontaining.py
@@ -16,8 +16,6 @@ class IsSequenceOnlyContaining(BaseMatcher):
     def _matches(self, sequence):
         try:
             sequence = list(sequence)
-            if len(sequence) == 0:
-                return False
             for item in sequence:
                 if not self.matcher.matches(item):
                     return False

--- a/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
@@ -37,8 +37,8 @@ class IsSequenceOnlyContainingTestBase(object):
         self.assert_does_not_match('3 is not less than 3',
                                    only_contains(less_than(3)), self._sequence(1, 2, 3))
 
-    def testDoesNotMatchEmptyList(self):
-        self.assert_does_not_match('empty', only_contains('foo'), self._sequence())
+    def testMatchesEmptyList(self):
+        self.assert_matches('empty', only_contains('foo'), self._sequence())
 
     def testMatchesAnyConformingSequence(self):
         class ObjectWithLenOnly(object):


### PR DESCRIPTION
Logically, `only_contains` should pass when the list to check is empty.