### PR TITLE
Handle SystemExit with raises.

### DIFF
--- a/devel-requirements.txt
+++ b/devel-requirements.txt
@@ -1,4 +1,3 @@
 six>=1.4
-tox>=1.8
 pytest>=2.6
 Sphinx>=1.2.2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --cov hamcrest --cov-report term-missing --no-cov-on-fail

--- a/src/hamcrest/core/core/raises.py
+++ b/src/hamcrest/core/core/raises.py
@@ -28,7 +28,7 @@ class Raises(BaseMatcher):
         self.actual = None
         try:
             function()
-        except Exception:
+        except BaseException:
             self.actual = sys.exc_info()[1]
 
             if isinstance(self.actual, self.expected):

--- a/tests/hamcrest_unit_test/core/raises_test.py
+++ b/tests/hamcrest_unit_test/core/raises_test.py
@@ -22,6 +22,10 @@ def raise_exception(*args, **kwargs):
     raise AssertionError(str(args) + str(kwargs))
 
 
+def raise_baseException(*args, **kwargs):
+    raise SystemExit(str(args) + str(kwargs))
+
+
 class RaisesTest(MatcherTest):
     def testMatchesIfFunctionRaisesTheExactExceptionExpected(self):
         self.assert_matches('Right exception',
@@ -37,6 +41,11 @@ class RaisesTest(MatcherTest):
         self.assert_matches('Subclassed Exception',
                             raises(Exception),
                             calling(raise_exception))
+
+    def testMatchesIfFunctionRaisesASubclassOfTheExpectedBaseException(self):
+        self.assert_matches('Subclassed BasedException',
+                            raises(BaseException),
+                            calling(raise_baseException))
 
     def testDoesNotMatchIfFunctionDoesNotRaiseException(self):
         self.assert_does_not_match('No exception',


### PR DESCRIPTION
This is for issue #73, for which I ran into the same problem today.

The [python doc for SystemExit](https://docs.python.org/3/library/exceptions.html?highlight=systemexit#SystemExit) states that SystemExit "inherits from BaseException instead of Exception".  

The code in Raises._call_function was updated to use BaseException.  A unit test was added and the tests run to make sure all tests passed.
