### PR TITLE
Fix #86, broken CI build, by removing the --use-mirors flag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,26 @@
 language: python
 
 python:
-  - 2.7
+  - 3.6
 
 env:
-  - TOX_ENV=py33
-  - TOX_ENV=py33-numpy
-  - TOX_ENV=py32
-  - TOX_ENV=py27
-  - TOX_ENV=py27-numpy
   - TOX_ENV=py26
-  - TOX_ENV=pypy
+  - TOX_ENV=py27
+  - TOX_ENV=pypy2.7
+  - TOX_ENV=py27-numpy
+  - TOX_ENV=py32
+  - TOX_ENV=py33
+  - TOX_ENV=py34
+  - TOX_ENV=py36
+  - TOX_ENV=py36-numpy
+  - TOX_ENV=pypy3.6
   - TOX_ENV=docs-py3
 
 before_install:
   - export EASY_SETUP_URL='http://peak.telecommunity.com/dist/ez_setup.py'
 
 install:
-  - pip install --use-mirrors tox coveralls
+  - pip install tox coveralls
 
 script:
   - tox -e $TOX_ENV

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,7 @@ from hamcrest import __version__
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
 
-autodoc_default_flags = ['members', 'show-inheritance']
+autodoc_default_options = {'members': None, 'show-inheritance': None}
 intersphinx_mapping = {'python': ('http://docs.python.org/2.6', None)}
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,docs-py3
+envlist = py26,py27,py32,py33,py34,py35,py36,pypy2.7,pypy3.6,docs-py3
 # envlist = py26,py27,py27-numpy,py32,py33,py33-numpy,pypy
 # Jython is not testable, but there's no reason it should not work.
 # py25 and py31 are deprecated as of 1.7.2
@@ -27,8 +27,8 @@ basepython = python2.7
 deps      = {[testenv]deps}
             numpy
 
-[testenv:py33-numpy]
-basepython = python3.3
+[testenv:py36-numpy]
+basepython = python3.6
 deps      = {[testenv]deps}
             numpy
 setenv    =
@@ -41,13 +41,15 @@ deps      = {[testenv]deps}
             numpy
 
 [testenv:docs-py3]
-basepython = python3.4
+basepython = python3.6
 deps       = sphinx
+             sphinx_rtd_theme
 changedir  = {toxinidir}/doc
 commands   = sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
 [testenv:docs-py2]
 basepython = python2.7
 deps       = sphinx
+             sphinx_rtd_theme
 changedir  = {toxinidir}/doc
 commands   = sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
Build seems to be working now. I've had to focus on Python versions 2.7 and 3.6, though we are still testing most older versions. (3.5 is missing from Travis, for some reason, but we are testing on 3.4 and 3.6, so fingers crossed.)

We are only testing numpy with 2.7 and 3.6 now. I couldn't get 3.3 working on Travis.

We are using 2.6 to generate the docs. here were also a couple of configuration changes to be made here, probably because of sphinx changes. Might we consider pinning dependency versions in future?