### PR TITLE
Add `not_` to the matcher-list in the Readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ PyHamcrest comes with a library of useful matchers:
   * ``all_of`` - ``and`` together all matchers
   * ``any_of`` - ``or`` together all matchers
   * ``anything`` - match anything, useful in composite matchers when you don't care about a particular value
-  * ``is_not`` - negate the matcher
+  * ``is_not``, ``not_`` - negate the matcher
 
 * Sequence
 


### PR DESCRIPTION
`not_` is an alias for `is_not` which is used for readability reasons. It should be mentioned in the Readme because this is the list where many people look for a list of matchers, especially as long as #74 is not fixed.