### PR TITLE
Possible fix for #72 - make has_properties mismatch description less verbose

### DIFF
--- a/src/hamcrest/core/core/allof.py
+++ b/src/hamcrest/core/core/allof.py
@@ -8,15 +8,17 @@ __license__ = "BSD, see License.txt"
 
 class AllOf(BaseMatcher):
 
-    def __init__(self, *matchers):
+    def __init__(self, *matchers, describe_matcher_in_mismatch=True):
         self.matchers = matchers
+        self.describe_matcher_in_mismatch = describe_matcher_in_mismatch
 
     def matches(self, item, mismatch_description=None):
         for matcher in self.matchers:
             if not matcher.matches(item):
                 if mismatch_description:
-                    mismatch_description.append_description_of(matcher) \
-                                        .append_text(' ')
+                    if self.describe_matcher_in_mismatch:
+                        mismatch_description.append_description_of(matcher) \
+                                            .append_text(' ')
                     matcher.describe_mismatch(item, mismatch_description)
                 return False
         return True

--- a/src/hamcrest/core/core/allof.py
+++ b/src/hamcrest/core/core/allof.py
@@ -8,9 +8,9 @@ __license__ = "BSD, see License.txt"
 
 class AllOf(BaseMatcher):
 
-    def __init__(self, *matchers, describe_matcher_in_mismatch=True):
+    def __init__(self, *matchers, **kwargs):
         self.matchers = matchers
-        self.describe_matcher_in_mismatch = describe_matcher_in_mismatch
+        self.describe_matcher_in_mismatch = kwargs.pop('describe_matcher_in_mismatch', True)  # No keyword-only args in 2.7 :-(
 
     def matches(self, item, mismatch_description=None):
         for matcher in self.matchers:

--- a/src/hamcrest/library/object/hasproperty.py
+++ b/src/hamcrest/library/object/hasproperty.py
@@ -1,8 +1,7 @@
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core import anything
-from hamcrest.core.core.allof import all_of
+from hamcrest.core.core.allof import AllOf
 from hamcrest.core.string_description import StringDescription
-from hamcrest.core.helpers.hasmethod import hasmethod
 from hamcrest.core.helpers.wrap_matcher import wrap_matcher as wrap_shortcut
 
 __author__ = "Chris Rose"
@@ -152,5 +151,6 @@ def has_properties(*keys_valuematchers, **kv_args):
     for key, value in kv_args.items():
         base_dict[key] = wrap_shortcut(value)
 
-    return all_of(*[has_property(property_name, property_value_matcher) for \
-                   property_name, property_value_matcher in base_dict.items()])
+    return AllOf(*[has_property(property_name, property_value_matcher) for \
+                   property_name, property_value_matcher in base_dict.items()],
+                 describe_matcher_in_mismatch=False)

--- a/src/hamcrest/library/object/hasproperty.py
+++ b/src/hamcrest/library/object/hasproperty.py
@@ -151,6 +151,6 @@ def has_properties(*keys_valuematchers, **kv_args):
     for key, value in kv_args.items():
         base_dict[key] = wrap_shortcut(value)
 
-    return AllOf(*[has_property(property_name, property_value_matcher) for \
-                   property_name, property_value_matcher in base_dict.items()],
+    return AllOf(*[has_property(property_name, property_value_matcher)
+                   for property_name, property_value_matcher in base_dict.items()],
                  describe_matcher_in_mismatch=False)

--- a/tests/hamcrest_unit_test/object/hasproperty_test.py
+++ b/tests/hamcrest_unit_test/object/hasproperty_test.py
@@ -5,7 +5,6 @@ if __name__ == '__main__':
 
 from hamcrest.library.object.hasproperty import *
 
-from hamcrest.core.core.isequal import equal_to
 from hamcrest_unit_test.matcher_test import MatcherTest
 import unittest
 
@@ -136,6 +135,12 @@ class HasPropertiesTest(MatcherTest, ObjectPropertyMatcher):
     def testMatchesUsingKeywordArguments(self):
         self.assert_matches_for_all_types('matches using a kwarg dict',
                                           has_properties(field='value', field2='value2'))
+
+    def testMismatchDescription(self):
+        self.assert_describe_mismatch("property 'field' was 'value'",
+                                      has_properties(field='different'),
+                                      OnePropertyNewStyle())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Possible fix for #72 - make has_properties mismatch description less verbose by adding option to `AllOf` not to include matcher description in its mismatch messages.

Before:
```
assert_that(b, has_properties(x=6, y=7))
Expected: (an object with a property 'x' matching <6> and an object with a property 'y' matching <7>)
     but: an object with a property 'x' matching <6> and an object with a property 'y' matching <7> property 'x' was <7>
```

After:
```
assert_that(b, has_properties(x=6, y=7))
Expected: (an object with a property 'x' matching <6> and an object with a property 'y' matching <7>)
     but: property 'x' was <7>
```