### PR TITLE
has_properties() report all mismatches.

### DIFF
--- a/src/hamcrest/core/core/allof.py
+++ b/src/hamcrest/core/core/allof.py
@@ -11,17 +11,23 @@ class AllOf(BaseMatcher):
     def __init__(self, *matchers, **kwargs):
         self.matchers = matchers
         self.describe_matcher_in_mismatch = kwargs.pop('describe_matcher_in_mismatch', True)  # No keyword-only args in 2.7 :-(
+        self.describe_all_mismatches = kwargs.pop('describe_all_mismatches', False)
 
     def matches(self, item, mismatch_description=None):
-        for matcher in self.matchers:
+        found_mismatch = False
+        for i, matcher in enumerate(self.matchers):
             if not matcher.matches(item):
                 if mismatch_description:
                     if self.describe_matcher_in_mismatch:
                         mismatch_description.append_description_of(matcher) \
                                             .append_text(' ')
                     matcher.describe_mismatch(item, mismatch_description)
-                return False
-        return True
+                found_mismatch = True
+                if not self.describe_all_mismatches:
+                    break
+                elif i < len(self.matchers) - 1:
+                    mismatch_description.append_text(' and ')
+        return not found_mismatch
 
     def describe_mismatch(self, item, mismatch_description):
         self.matches(item, mismatch_description)

--- a/src/hamcrest/library/object/hasproperty.py
+++ b/src/hamcrest/library/object/hasproperty.py
@@ -152,6 +152,6 @@ def has_properties(*keys_valuematchers, **kv_args):
         base_dict[key] = wrap_shortcut(value)
 
     return AllOf(*[has_property(property_name, property_value_matcher)
-                   for property_name, property_value_matcher in base_dict.items()],
+                   for property_name, property_value_matcher in sorted(base_dict.items())],
                  describe_all_mismatches=True,
                  describe_matcher_in_mismatch=False)

--- a/src/hamcrest/library/object/hasproperty.py
+++ b/src/hamcrest/library/object/hasproperty.py
@@ -1,8 +1,8 @@
-from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core import anything
+from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.core.allof import AllOf
-from hamcrest.core.string_description import StringDescription
 from hamcrest.core.helpers.wrap_matcher import wrap_matcher as wrap_shortcut
+from hamcrest.core.string_description import StringDescription
 
 __author__ = "Chris Rose"
 __copyright__ = "Copyright 2011 hamcrest.org"
@@ -153,4 +153,5 @@ def has_properties(*keys_valuematchers, **kv_args):
 
     return AllOf(*[has_property(property_name, property_value_matcher)
                    for property_name, property_value_matcher in base_dict.items()],
+                 describe_all_mismatches=True,
                  describe_matcher_in_mismatch=False)

--- a/tests/hamcrest_unit_test/core/allof_test.py
+++ b/tests/hamcrest_unit_test/core/allof_test.py
@@ -77,6 +77,12 @@ class AllOfTest(MatcherTest):
                                 all_of(equal_to('bad'), equal_to('good')),
                                 'bad')
 
+    def testMismatchDescriptionOptionallyDescribesMultipleFailingMatches(self):
+        self.assert_mismatch_description(
+            "'bad' was 'indifferent' and 'good' was 'indifferent'",
+            AllOf(equal_to('bad'), equal_to('indifferent'), equal_to('good'), describe_all_mismatches=True),
+            'indifferent')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/hamcrest_unit_test/object/hasproperty_test.py
+++ b/tests/hamcrest_unit_test/object/hasproperty_test.py
@@ -17,13 +17,14 @@ class OnePropertyOldStyle:
     field = 'value'
     field2 = 'value2'
 
-class OnePropertyNewStyle(object):
+class ThreePropertiesNewStyle(object):
 
     field = 'value'
     field2 = 'value2'
+    field3 = 'value3'
 
     def __repr__(self):
-        return 'OnePropertyNewStyle'
+        return 'ThreePropertiesNewStyle'
 
     def __str__(self):
         return repr(self)
@@ -63,7 +64,7 @@ class ObjectPropertyMatcher(object):
 
     match_sets = (
         ("old-style: %s", OnePropertyOldStyle),
-        ('new-style: %s', OnePropertyNewStyle),
+        ('new-style: %s', ThreePropertiesNewStyle),
         ('old-style, overriding: %s', OverridingOldStyle),
         ('new-style, using getattr: %s', OverridingNewStyleGetAttr),
         ('new-style, using getattribute: %s', OverridingNewStyleGetAttribute),
@@ -106,20 +107,20 @@ class HasPropertyTest(MatcherTest, ObjectPropertyMatcher):
                                 has_property('field', 'value'))
 
     def testDescribeMissingProperty(self):
-        self.assert_mismatch_description("<OnePropertyNewStyle> did not have the 'not_there' property",
-                                         has_property('not_there'), OnePropertyNewStyle())
+        self.assert_mismatch_description("<ThreePropertiesNewStyle> did not have the 'not_there' property",
+                                         has_property('not_there'), ThreePropertiesNewStyle())
 
     def testDescribePropertyValueMismatch(self):
         self.assert_mismatch_description("property 'field' was 'value'",
-                                         has_property('field', 'another_value'), OnePropertyNewStyle())
+                                         has_property('field', 'another_value'), ThreePropertiesNewStyle())
 
     def testMismatchDescription(self):
-        self.assert_describe_mismatch("<OnePropertyNewStyle> did not have the 'not_there' property",
+        self.assert_describe_mismatch("<ThreePropertiesNewStyle> did not have the 'not_there' property",
                                       has_property('not_there'),
-                                      OnePropertyNewStyle())
+                                      ThreePropertiesNewStyle())
 
     def testNoMismatchDescriptionOnMatch(self):
-        self.assert_no_mismatch_description(has_property('field', 'value'), OnePropertyNewStyle())
+        self.assert_no_mismatch_description(has_property('field', 'value'), ThreePropertiesNewStyle())
 
 
 class HasPropertiesTest(MatcherTest, ObjectPropertyMatcher):
@@ -137,9 +138,9 @@ class HasPropertiesTest(MatcherTest, ObjectPropertyMatcher):
                                           has_properties(field='value', field2='value2'))
 
     def testMismatchDescription(self):
-        self.assert_describe_mismatch("property 'field' was 'value'",
-                                      has_properties(field='different'),
-                                      OnePropertyNewStyle())
+        self.assert_describe_mismatch("property 'field' was 'value' and property 'field3' was 'value3'",
+                                      has_properties(field='different', field2='value2', field3='alsodifferent'),
+                                      ThreePropertiesNewStyle())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Rather than reporting only the first mismatching property, report all mismatching properties.

Before:
```
b = SomeClass(x=7, y=7, z=99)
assert_that(b, has_properties(x=6, y=7, z=8))
Expected: (an object with a property 'x' matching <6> and an object with a property 'y' matching <7> and an object with a property 'y' matching <8>)
     but: property 'x' was <7>
```

After:
```
b = SomeClass(x=7, y=7, z=99)
assert_that(b, has_properties(x=6, y=7, z=8))
Expected: (an object with a property 'x' matching <6> and an object with a property 'y' matching <7> and an object with a property 'y' matching <8>)
     but: property 'x' was <7> and property 'z' was <99>
```
