### PR TITLE
Improve has_properties description.

### DIFF
--- a/src/hamcrest/library/object/hasproperty.py
+++ b/src/hamcrest/library/object/hasproperty.py
@@ -1,3 +1,4 @@
+from hamcrest import described_as
 from hamcrest.core import anything
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.core.allof import AllOf
@@ -151,7 +152,20 @@ def has_properties(*keys_valuematchers, **kv_args):
     for key, value in kv_args.items():
         base_dict[key] = wrap_shortcut(value)
 
-    return AllOf(*[has_property(property_name, property_value_matcher)
-                   for property_name, property_value_matcher in sorted(base_dict.items())],
-                 describe_all_mismatches=True,
-                 describe_matcher_in_mismatch=False)
+    if len(base_dict) > 1:
+        description = StringDescription().append_text('an object with properties ')
+        for i, (property_name, property_value_matcher) in enumerate(sorted(base_dict.items())):
+            description.append_value(property_name).append_text(' matching ').append_description_of(
+                property_value_matcher)
+            if i < len(base_dict) - 1:
+                description.append_text(' and ')
+
+        return described_as(str(description),
+                            AllOf(*[has_property(property_name, property_value_matcher)
+                                    for property_name, property_value_matcher
+                                    in sorted(base_dict.items())],
+                                  describe_all_mismatches=True,
+                                  describe_matcher_in_mismatch=False))
+    else:
+        property_name, property_value_matcher = base_dict.popitem()
+        return has_property(property_name, property_value_matcher)

--- a/tests/hamcrest_unit_test/object/hasproperty_test.py
+++ b/tests/hamcrest_unit_test/object/hasproperty_test.py
@@ -3,10 +3,11 @@ if __name__ == '__main__':
     sys.path.insert(0, '..')
     sys.path.insert(0, '../..')
 
-from hamcrest.library.object.hasproperty import *
-
-from hamcrest_unit_test.matcher_test import MatcherTest
 import unittest
+
+from hamcrest import greater_than
+from hamcrest.library.object.hasproperty import *
+from hamcrest_unit_test.matcher_test import MatcherTest
 
 __author__ = "Chris Rose"
 __copyright__ = "Copyright 2011 hamcrest.org"
@@ -141,6 +142,12 @@ class HasPropertiesTest(MatcherTest, ObjectPropertyMatcher):
         self.assert_describe_mismatch("property 'field' was 'value' and property 'field3' was 'value3'",
                                       has_properties(field='different', field2='value2', field3='alsodifferent'),
                                       ThreePropertiesNewStyle())
+
+    def testDescription(self):
+        self.assert_description("an object with a property 'a' matching <1>", has_properties(a=1))
+        self.assert_description("an object with properties 'a' matching <1> "
+                                "and 'b' matching a value greater than <2>",
+                                has_properties(a=1, b=greater_than(2)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before:

```python
str(has_properties(x=6, y=5, z=7))
(an object with a property 'x' matching <6> and an object with a property 'y' matching <5> and an object with a property 'z' matching <7>)
```

After:

```python
str(has_properties(x=6, y=5, z=7))
an object with properties 'x' matching <6> and 'y' matching <5> and 'z' matching <7>
```