### PR TITLE
Fix crash when receiving unexpected input

### DIFF
--- a/src/hamcrest/core/string_description.py
+++ b/src/hamcrest/core/string_description.py
@@ -35,4 +35,10 @@ class StringDescription(BaseDescription):
         return self.out
 
     def append(self, string):
-        self.out += six.text_type(string)
+        if six.PY3:
+            self.out += str(string)
+        else:
+            if isinstance(string, unicode):
+                self.out += string
+            else:
+                self.out += unicode(string, errors="ignore")

--- a/tests/hamcrest_unit_test/string_description_test.py
+++ b/tests/hamcrest_unit_test/string_description_test.py
@@ -61,5 +61,10 @@ def test_description_append_valid_input(valid_input):
     desc.append(valid_input)
     str(desc)
 
+
+def test_description_append_invalid_input():
+    desc = StringDescription()
+    desc.append(chr(239))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit fixes crashes like these:

UnicodeDecodeError: 'ascii' codec can't decode byte 0xbe in position
0: ordinal not in range(128)

on Python 2.