### PR TITLE
 Add describe_match()

### DIFF
--- a/doc/custom_matchers.rst
+++ b/doc/custom_matchers.rst
@@ -74,3 +74,30 @@ Even though the ``on_a_saturday`` function creates a new matcher each time it
 is called, you should not assume this is the only usage pattern for your
 matcher. Therefore you should make sure your matcher is stateless, so a single
 instance can be reused between matches.
+
+If you need your matcher to provide more details in case of a mismatch, you
+can override the :py:meth:`~hamcrest.core.base_matcher.BaseMatcher.describe_mismatch`
+method. For example, if we added this
+:py:meth:`~hamcrest.core.base_matcher.BaseMatcher.describe_mismatch` implementation
+to our ``IsGivenDayOfWeek`` matcher::
+
+    def describe_mismatch(self, item, mismatch_description):
+        day_as_string = ['Monday', 'Tuesday', 'Wednesday', 'Thursday',
+                         'Friday', 'Saturday', 'Sunday']
+        mismatch_description.append_text('got ') \
+                            .append_description_of(item) \
+                            .append_text(' which is a ') \
+                            .append_text(day_as_string[item.weekday()])
+
+Our matcher would now give the message::
+
+    AssertionError:
+    Expected: is calendar date falling on Saturday
+         got: <2008-04-06> which is a Sunday
+
+
+Occasionally, you might also need your matcher to explain why it matched successfully.
+For example, if your matcher is wrapped by a :py:meth:`~hamcrest.core.core.isnot.is_not`
+matcher, the ``is_not`` matcher can only explain its mismatches by understanding why your
+matcher succeeded. In this case, your matcher can implement
+:py:meth:`~hamcrest.core.base_matcher.BaseMatcher.describe_match`.

--- a/src/hamcrest/core/base_matcher.py
+++ b/src/hamcrest/core/base_matcher.py
@@ -31,3 +31,6 @@ class BaseMatcher(Matcher):
 
     def describe_mismatch(self, item, mismatch_description):
         mismatch_description.append_text("was ").append_description_of(item)
+
+    def describe_match(self, item, match_description):
+        match_description.append_text("was ").append_description_of(item)

--- a/src/hamcrest/core/core/isnot.py
+++ b/src/hamcrest/core/core/isnot.py
@@ -18,6 +18,10 @@ class IsNot(BaseMatcher):
     def describe_to(self, description):
         description.append_text("not ").append_description_of(self.matcher)
 
+    def describe_mismatch(self, item, mismatch_description):
+        mismatch_description.append_text("but ")
+        self.matcher.describe_match(item, mismatch_description)
+
 
 def wrap_value_or_type(x):
     if is_matchable_type(x):

--- a/src/hamcrest/core/core/raises.py
+++ b/src/hamcrest/core/core/raises.py
@@ -63,6 +63,12 @@ class Raises(BaseMatcher):
                 "%r of type %s was raised instead" % (self.actual, type(self.actual))
             )
 
+    def describe_match(self, item, match_description):
+        self._call_function(item)
+        match_description.append_text(
+            "%r of type %s was raised." % (self.actual, type(self.actual))
+        )
+
 
 def raises(exception, pattern=None):
     """Matches if the called function raised the expected exception.

--- a/src/hamcrest/core/matcher.py
+++ b/src/hamcrest/core/matcher.py
@@ -49,3 +49,19 @@ class Matcher(SelfDescribing):
 
         """
         raise NotImplementedError("describe_mismatch")
+
+    def describe_match(self, item, match_description):
+        """Generates a description of why the matcher has accepted the item.
+
+        The description may be part of a larger description of why a matching
+        failed, so it should be concise.
+
+        This method assumes that ``matches(item)`` is ``True``, but will not
+        check this.
+
+        :param item: The item that the
+            :py:class:`~hamcrest.core.matcher.Matcher` has accepted.
+        :param match_description: The description to be built or appended to.
+
+        """
+        raise NotImplementedError("describe_match")

--- a/tests/hamcrest_unit_test/base_matcher_test.py
+++ b/tests/hamcrest_unit_test/base_matcher_test.py
@@ -6,21 +6,36 @@ if __name__ == "__main__":
 import unittest
 
 from hamcrest.core.base_matcher import *
+from hamcrest_unit_test.matcher_test import *
 
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
 __license__ = "BSD, see License.txt"
 
 
-class TestingBaseMatcher(BaseMatcher):
+class FailingBaseMatcher(BaseMatcher):
     def describe_to(self, description):
         description.append_text("SOME DESCRIPTION")
+
+    def _matches(self, item):
+        return False
+
+
+class PassingBaseMatcher(BaseMatcher):
+    def _matches(self, item):
+        return True
 
 
 class BaseMatcherTest(unittest.TestCase):
     def testStrFunctionShouldDescribeMatcher(self):
-        matcher = TestingBaseMatcher()
+        matcher = FailingBaseMatcher()
         self.assertEqual("SOME DESCRIPTION", str(matcher))
+
+    def testMismatchDescriptionShouldDescribeItem(self):
+        assert_mismatch_description("was <99>", FailingBaseMatcher(), 99)
+
+    def testMatchDescriptionShouldDescribeItem(self):
+        assert_match_description("was <99>", PassingBaseMatcher(), 99)
 
 
 if __name__ == "__main__":

--- a/tests/hamcrest_unit_test/core/isnone_test.py
+++ b/tests/hamcrest_unit_test/core/isnone_test.py
@@ -48,10 +48,10 @@ class NotNoneTest(MatcherTest):
         self.assert_no_mismatch_description(not_none(), "hi")
 
     def testMismatchDescriptionShowsActualArgument(self):
-        self.assert_mismatch_description("was <None>", not_none(), None)
+        self.assert_mismatch_description("but was <None>", not_none(), None)
 
     def testDescribeMismatch(self):
-        self.assert_describe_mismatch("was <None>", not_none(), None)
+        self.assert_describe_mismatch("but was <None>", not_none(), None)
 
 
 if __name__ == "__main__":

--- a/tests/hamcrest_unit_test/core/isnot_test.py
+++ b/tests/hamcrest_unit_test/core/isnot_test.py
@@ -35,10 +35,10 @@ class IsNotTest(MatcherTest):
         self.assert_no_mismatch_description(is_not("A"), "B")
 
     def testMismatchDescriptionShowsActualArgument(self):
-        self.assert_mismatch_description("was 'A'", is_not("A"), "A")
+        self.assert_mismatch_description("but was 'A'", is_not("A"), "A")
 
     def testDescribeMismatch(self):
-        self.assert_describe_mismatch("was 'A'", is_not("A"), "A")
+        self.assert_describe_mismatch("but was 'A'", is_not("A"), "A")
 
 
 if __name__ == "__main__":

--- a/tests/hamcrest_unit_test/matcher_test.py
+++ b/tests/hamcrest_unit_test/matcher_test.py
@@ -70,6 +70,15 @@ def assert_mismatch_description(expected, matcher, arg):
     assert expected == str(description)
 
 
+def assert_match_description(expected, matcher, item):
+    result = matcher.matches(item, StringDescription())
+    assert result, "Precondition: Matcher should match item"
+
+    description = StringDescription()
+    matcher.describe_match(item, description)
+    assert expected == str(description)
+
+
 def assert_describe_mismatch(expected, matcher, arg):
     description = StringDescription()
     matcher.describe_mismatch(arg, description)


### PR DESCRIPTION
Fix for #111. Add `describe_match()` to `Matcher` and `BaseMatcher`, and use it in `IsNot` to better describe mismatches there, specifically in `Raises`. 