### PR TITLE
Python version compatibility metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ params = dict(
     package_dir={"": "src"},
     provides=["hamcrest"],
     long_description=read("README.rst"),
+    python_requires='>=3.5',
     install_requires=[],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ params = dict(
     package_dir={"": "src"},
     provides=["hamcrest"],
     long_description=read("README.rst"),
-    python_requires='>=3.5',
+    python_requires=">=3.5",
     install_requires=[],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR adds packaging metadata that marks the package as only supporting Python 3.5+. This prevents Pip from installing it on Python 2.7.

You can find documentation here: https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords (search in page for "python_requires").

I'm not sure how you do releases, but I'll note that you may need non-ancient (last four years or so) setuptools to generate a wheel that contains this metadata.

Fixes #131.