### PR TITLE
Use `Union[Matcher[T], T]` rather than `Union[T, Matcher[T]]`.

### DIFF
--- a/src/hamcrest/core/core/allof.py
+++ b/src/hamcrest/core/core/allof.py
@@ -42,7 +42,7 @@ class AllOf(BaseMatcher[T]):
         description.append_list("(", " and ", ")", self.matchers)
 
 
-def all_of(*items: Union[T, Matcher[T]]) -> Matcher[T]:
+def all_of(*items: Union[Matcher[T], T]) -> Matcher[T]:
     """Matches if all of the given matchers evaluate to ``True``.
 
     :param matcher1,...:  A comma-separated list of matchers.

--- a/src/hamcrest/core/core/anyof.py
+++ b/src/hamcrest/core/core/anyof.py
@@ -26,7 +26,7 @@ class AnyOf(BaseMatcher[T]):
         description.append_list("(", " or ", ")", self.matchers)
 
 
-def any_of(*items: Union[T, Matcher[T]]) -> Matcher[T]:
+def any_of(*items: Union[Matcher[T], T]) -> Matcher[T]:
     """Matches if any of the given matchers evaluate to ``True``.
 
     :param matcher1,...:  A comma-separated list of matchers.

--- a/src/hamcrest/library/collection/issequence_containing.py
+++ b/src/hamcrest/library/collection/issequence_containing.py
@@ -54,7 +54,7 @@ class IsSequenceContainingEvery(BaseMatcher[Sequence[T]]):
         self.matcher.describe_to(description)
 
 
-def has_item(match: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
+def has_item(match: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     """Matches if any element of sequence satisfies a given matcher.
 
     :param match: The matcher to satisfy, or an expected value for
@@ -72,7 +72,7 @@ def has_item(match: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
     return IsSequenceContaining(wrap_matcher(match))
 
 
-def has_items(*items: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
+def has_items(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     """Matches if all of the given matchers are satisfied by any elements of
     the sequence.
 

--- a/src/hamcrest/library/collection/issequence_containinginanyorder.py
+++ b/src/hamcrest/library/collection/issequence_containinginanyorder.py
@@ -79,7 +79,7 @@ class IsSequenceContainingInAnyOrder(BaseMatcher[Sequence[T]]):
         ).append_text(" in any order")
 
 
-def contains_inanyorder(*items: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
+def contains_inanyorder(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     """Matches if sequences's elements, in any order, satisfy a given list of
     matchers.
 

--- a/src/hamcrest/library/collection/issequence_containinginorder.py
+++ b/src/hamcrest/library/collection/issequence_containinginorder.py
@@ -78,7 +78,7 @@ class IsSequenceContainingInOrder(BaseMatcher[Sequence[T]]):
         description.append_text("a sequence containing ").append_list("[", ", ", "]", self.matchers)
 
 
-def contains_exactly(*items: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
+def contains_exactly(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     """Matches if sequence's elements satisfy a given list of matchers, in order.
 
     :param match1,...: A comma-separated list of matchers.
@@ -97,7 +97,7 @@ def contains_exactly(*items: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
     return IsSequenceContainingInOrder(matchers)
 
 
-def contains(*items: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
+def contains(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     """Deprecated - use contains_exactly(*items)"""
     warnings.warn("deprecated - use contains_exactly(*items)", DeprecationWarning)
     return contains_exactly(*items)

--- a/src/hamcrest/library/collection/issequence_onlycontaining.py
+++ b/src/hamcrest/library/collection/issequence_onlycontaining.py
@@ -35,7 +35,7 @@ class IsSequenceOnlyContaining(BaseMatcher[Sequence[T]]):
         )
 
 
-def only_contains(*items: Union[T, Matcher[T]]) -> Matcher[Sequence[T]]:
+def only_contains(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     """Matches if each element of sequence satisfies any of the given matchers.
 
     :param match1,...: A comma-separated list of matchers.


### PR DESCRIPTION
The latter way, the `T` picks up all types, and the `Matcher[T]` is never picked up.