### PR TITLE
add has_return_value matcher.

### DIFF
--- a/doc/object_matchers.rst
+++ b/doc/object_matchers.rst
@@ -24,10 +24,10 @@ has_properties/has_property
 
 .. automodule:: hamcrest.library.object.hasproperty
 
-has_callable_value
+has_return_value
 ^^^^^^^^^^^^^^^^^^
 
-.. automodule:: hamcrest.library.object.hascallablevalue
+.. automodule:: hamcrest.library.object.hasreturnvalue
 
 instance_of
 ^^^^^^^^^^^

--- a/doc/object_matchers.rst
+++ b/doc/object_matchers.rst
@@ -24,6 +24,11 @@ has_properties/has_property
 
 .. automodule:: hamcrest.library.object.hasproperty
 
+has_callable_value
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: hamcrest.library.object.hascallablevalue
+
 instance_of
 ^^^^^^^^^^^
 

--- a/src/hamcrest/library/object/__init__.py
+++ b/src/hamcrest/library/object/__init__.py
@@ -1,8 +1,8 @@
 """Matchers that inspect objects and classes."""
 
-from .hasreturnvalue import has_return_value
 from .haslength import has_length
 from .hasproperty import has_properties, has_property
+from .hasreturnvalue import has_return_value
 from .hasstring import has_string
 
 __author__ = "Jon Reid"

--- a/src/hamcrest/library/object/__init__.py
+++ b/src/hamcrest/library/object/__init__.py
@@ -1,5 +1,6 @@
 """Matchers that inspect objects and classes."""
 
+from .hasreturnvalue import has_return_value
 from .haslength import has_length
 from .hasproperty import has_properties, has_property
 from .hasstring import has_string

--- a/src/hamcrest/library/object/hasreturnvalue.py
+++ b/src/hamcrest/library/object/hasreturnvalue.py
@@ -1,0 +1,131 @@
+from typing import Any, Iterable, Mapping, TypeVar, Union, overload
+
+from hamcrest import described_as
+from hamcrest.core import not_none
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.core.allof import AllOf
+from hamcrest.core.description import Description
+from hamcrest.core.helpers.wrap_matcher import wrap_matcher as wrap_shortcut
+from hamcrest.core.matcher import Matcher
+from hamcrest.core.string_description import StringDescription
+
+__author__ = "Perry Goy"
+__copyright__ = "Copyright 2011 hamcrest.org"
+__license__ = "BSD, see License.txt"
+
+V = TypeVar("V")
+
+
+class IsObjectWithCallableProducingValue(BaseMatcher[object]):
+    def __init__(
+        self, 
+        method_name: str, 
+        value_matcher: Matcher[V], 
+        args: Iterable[Any] = None, 
+        kwargs: Mapping[str, Any] = None
+    ) -> None:
+        self.method_name = method_name
+        self.args = args if args is not None else []
+        self.kwargs = kwargs if kwargs is not None else {}
+        self.value_matcher = value_matcher
+
+    def get_callargs_str(self):
+        args_str = ", ".join(map(str, self.args)) if self.args else ""
+
+        kwargs_str = ""
+        if self.kwargs:
+            kwargs_bits = map(lambda x: "=".join(map(str, x)), self.kwargs.items())
+            kwargs_str = ", ".join(kwargs_bits)
+
+        if args_str and kwargs_str:
+            kwargs_str = ", " + kwargs_str
+
+        return "(" + args_str + kwargs_str + ")"
+
+    def get_return_value(self, item):
+        return getattr(item, self.method_name)(*self.args, **self.kwargs)
+
+    def _matches(self, item: object) -> bool:
+        if item is None:
+            return False
+
+        if not hasattr(item, self.method_name):
+            return False
+
+        return_value = self.get_return_value(item)
+        return self.value_matcher.matches(return_value)
+
+    def describe_to(self, description: Description) -> None:
+        description.append_text("an object with a method '").append_text(
+            self.method_name
+        ).append_text("' whose return value when called with ").append_text(
+            self.get_callargs_str()
+        ).append_text(" matches ").append_description_of(self.value_matcher)
+
+    def describe_mismatch(self, item: object, mismatch_description: Description) -> None:
+        if item is None:
+            mismatch_description.append_text("was None")
+            return
+
+        if not hasattr(item, self.method_name):
+            mismatch_description.append_description_of(item).append_text(
+                " did not have a "
+            ).append_description_of(self.method_name).append_text(" method")
+            return
+
+        mismatch_description.append_text("method ").append_description_of(
+            self.method_name
+        ).append_text(" called with ").append_text(
+            self.get_callargs_str()
+        ).append_text(" ")
+
+        self.value_matcher.describe_mismatch(
+            self.get_return_value(item), mismatch_description
+        )
+
+    def __str__(self):
+        d = StringDescription()
+        self.describe_to(d)
+        return str(d)
+
+
+def has_return_value(
+        name: str, 
+        match: Union[None, Matcher[V], V] = None,
+        args: Iterable[Any] = None, 
+        kwargs: Mapping[str, Any] = None,
+    ) -> Matcher[object]:
+    """Matches if object has a method with a given name whose return value when
+    called with the given args and kwargs satisfies a given matcher.
+
+    :param name: The name of the method.
+    :param match: Optional matcher to satisfy.
+    :param args: Optional list of arguments to pass to the method.
+    :param kwargs: Optional mapping of keyword arguments to pass to the method.
+
+    This matcher determines if the evaluated object has a method with a given
+    name. If no such method is found, ``has_return_value`` is not satisfied.
+
+    If the method is found, it is called with the given arguments and keyword
+    arguments, and its return value is passed to a given matcher for 
+    evaluation. If the ``match`` argument is not a matcher, it is implicitly
+    wrapped in an :py:func:`~hamcrest.core.core.isequal.equal_to` matcher to
+    check for equality.
+
+    If the ``match`` argument is not provided, the
+    :py:func:`~hamcrest.core.core.isnone.not_none` matcher is used so that
+    ``has_return_value`` is satisfied if a matching method is found which
+    returns something.
+
+    Examples::
+
+        has_return_value('is_displayed', True)
+        has_return_value('get_child', is_instance_of(Child))
+        has_return_value('name')
+
+    """
+
+    if match is None:
+        match = not_none()
+
+    return IsObjectWithCallableProducingValue(name, wrap_shortcut(match), args=args, kwargs=kwargs)

--- a/src/hamcrest/library/object/hasreturnvalue.py
+++ b/src/hamcrest/library/object/hasreturnvalue.py
@@ -34,7 +34,10 @@ class IsObjectWithCallableProducingValue(BaseMatcher[object]):
 
         kwargs_str = ""
         if self.kwargs:
-            kwargs_bits = map(lambda x: "=".join(map(str, x)), self.kwargs.items())
+            kwargs_bits = sorted(
+                map(lambda x: "=".join(map(str, x)), self.kwargs.items()), 
+                key=lambda x: x[0],
+            )
             kwargs_str = ", ".join(kwargs_bits)
 
         if args_str and kwargs_str:

--- a/src/hamcrest/library/object/hasreturnvalue.py
+++ b/src/hamcrest/library/object/hasreturnvalue.py
@@ -18,11 +18,11 @@ V = TypeVar("V")
 
 class IsObjectWithCallableProducingValue(BaseMatcher[object]):
     def __init__(
-        self, 
-        method_name: str, 
-        value_matcher: Matcher[V], 
-        args: Iterable[Any] = None, 
-        kwargs: Mapping[str, Any] = None
+        self,
+        method_name: str,
+        value_matcher: Matcher[V],
+        args: Iterable[Any] = None,
+        kwargs: Mapping[str, Any] = None,
     ) -> None:
         self.method_name = method_name
         self.args = args if args is not None else []
@@ -35,8 +35,7 @@ class IsObjectWithCallableProducingValue(BaseMatcher[object]):
         kwargs_str = ""
         if self.kwargs:
             kwargs_bits = map(
-                lambda x: "=".join(map(str, x)), 
-                sorted(self.kwargs.items(), key=lambda x: x[0])
+                lambda x: "=".join(map(str, x)), sorted(self.kwargs.items(), key=lambda x: x[0])
             )
             kwargs_str = ", ".join(kwargs_bits)
 
@@ -63,7 +62,11 @@ class IsObjectWithCallableProducingValue(BaseMatcher[object]):
             self.method_name
         ).append_text("' whose return value when called with ").append_text(
             self.get_callargs_str()
-        ).append_text(" matches ").append_description_of(self.value_matcher)
+        ).append_text(
+            " matches "
+        ).append_description_of(
+            self.value_matcher
+        )
 
     def describe_mismatch(self, item: object, mismatch_description: Description) -> None:
         if item is None:
@@ -78,13 +81,9 @@ class IsObjectWithCallableProducingValue(BaseMatcher[object]):
 
         mismatch_description.append_text("method ").append_description_of(
             self.method_name
-        ).append_text(" called with ").append_text(
-            self.get_callargs_str()
-        ).append_text(" ")
+        ).append_text(" called with ").append_text(self.get_callargs_str()).append_text(" ")
 
-        self.value_matcher.describe_mismatch(
-            self.get_return_value(item), mismatch_description
-        )
+        self.value_matcher.describe_mismatch(self.get_return_value(item), mismatch_description)
 
     def __str__(self):
         d = StringDescription()
@@ -93,11 +92,11 @@ class IsObjectWithCallableProducingValue(BaseMatcher[object]):
 
 
 def has_return_value(
-        name: str, 
-        match: Union[None, Matcher[V], V] = None,
-        args: Iterable[Any] = None, 
-        kwargs: Mapping[str, Any] = None,
-    ) -> Matcher[object]:
+    name: str,
+    match: Union[None, Matcher[V], V] = None,
+    args: Iterable[Any] = None,
+    kwargs: Mapping[str, Any] = None,
+) -> Matcher[object]:
     """Matches if object has a method with a given name whose return value when
     called with the given args and kwargs satisfies a given matcher.
 

--- a/src/hamcrest/library/object/hasreturnvalue.py
+++ b/src/hamcrest/library/object/hasreturnvalue.py
@@ -34,9 +34,9 @@ class IsObjectWithCallableProducingValue(BaseMatcher[object]):
 
         kwargs_str = ""
         if self.kwargs:
-            kwargs_bits = sorted(
-                map(lambda x: "=".join(map(str, x)), self.kwargs.items()), 
-                key=lambda x: x[0],
+            kwargs_bits = map(
+                lambda x: "=".join(map(str, x)), 
+                sorted(self.kwargs.items(), key=lambda x: x[0])
             )
             kwargs_str = ", ".join(kwargs_bits)
 

--- a/src/hamcrest/library/object/hasreturnvalue.py
+++ b/src/hamcrest/library/object/hasreturnvalue.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Mapping, TypeVar, Union, overload
+from typing import Any, Iterable, Mapping, Optional, TypeVar, Union, overload
 
 from hamcrest import described_as
 from hamcrest.core import not_none
@@ -93,7 +93,7 @@ class IsObjectWithCallableProducingValue(BaseMatcher[object]):
 
 def has_return_value(
     name: str,
-    match: Union[None, Matcher[V], V] = None,
+    match: Optional[Union[Matcher[V], V]] = None,
     args: Iterable[Any] = None,
     kwargs: Mapping[str, Any] = None,
 ) -> Matcher[object]:

--- a/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
+++ b/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
@@ -16,13 +16,12 @@ __license__ = "BSD, see License.txt"
 
 
 class MethodsOldStyle:
-
     def method1(self):
         return "value1"
-    
+
     def method2(self, arg1):
         return "value{}".format(arg1)
-    
+
     def method3(self, kwarg1=None):
         return "value{}".format(kwarg1)
 
@@ -34,13 +33,12 @@ class MethodsOldStyle:
 
 
 class MethodsNewStyle(object):
-
     def method1(self):
         return "value1"
-    
+
     def method2(self, arg1):
         return "value{}".format(arg1)
-    
+
     def method3(self, kwarg1=None):
         return "value{}".format(kwarg1)
 
@@ -68,7 +66,9 @@ class OverridingOldStyle:
         if name == "method4":
             return lambda arg1, kwarg1=None: "value{}{}".format(arg1, kwarg1)
         if name == "method5":
-            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(
+                arg1, arg2, kwarg1, kwarg2
+            )
 
         raise AttributeError(name)
 
@@ -84,7 +84,9 @@ class OverridingNewStyleGetAttr(object):
         if name == "method4":
             return lambda arg1, kwarg1=None: "value{}{}".format(arg1, kwarg1)
         if name == "method5":
-            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(
+                arg1, arg2, kwarg1, kwarg2
+            )
 
         raise AttributeError(name)
 
@@ -100,7 +102,9 @@ class OverridingNewStyleGetAttribute(object):
         if name == "method4":
             return lambda arg1, kwarg1=None: "value{}{}".format(arg1, kwarg1)
         if name == "method5":
-            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(
+                arg1, arg2, kwarg1, kwarg2
+            )
 
         raise AttributeError(name)
 
@@ -145,22 +149,30 @@ class HasReturnValueTest(MatcherTest, ObjectReturnValueMatcher):
 
     def testDescription(self):
         self.assert_description(
-            "an object with a method 'method1' whose return value when called with () matches not None", has_return_value("method1")
+            "an object with a method 'method1' whose return value when called with () matches not None",
+            has_return_value("method1"),
         )
         self.assert_description(
-            "an object with a method 'method1' whose return value when called with () matches 'value1'", has_return_value("method1", "value1")
+            "an object with a method 'method1' whose return value when called with () matches 'value1'",
+            has_return_value("method1", "value1"),
         )
         self.assert_description(
-            "an object with a method 'method2' whose return value when called with (1) matches 'value1'", has_return_value("method2", "value1", args=[1])
+            "an object with a method 'method2' whose return value when called with (1) matches 'value1'",
+            has_return_value("method2", "value1", args=[1]),
         )
         self.assert_description(
-            "an object with a method 'method3' whose return value when called with (kwarg1=1) matches 'value1'", has_return_value("method3", "value1", kwargs={"kwarg1": 1})
+            "an object with a method 'method3' whose return value when called with (kwarg1=1) matches 'value1'",
+            has_return_value("method3", "value1", kwargs={"kwarg1": 1}),
         )
         self.assert_description(
-            "an object with a method 'method4' whose return value when called with (1, kwarg1=1) matches 'value11'", has_return_value("method4", "value11", args=[1], kwargs={"kwarg1": 1})
+            "an object with a method 'method4' whose return value when called with (1, kwarg1=1) matches 'value11'",
+            has_return_value("method4", "value11", args=[1], kwargs={"kwarg1": 1}),
         )
         self.assert_description(
-            "an object with a method 'method5' whose return value when called with (1, 2, kwarg1=1, kwarg2=2) matches 'value1212'", has_return_value("method5", "value1212", args=[1, 2], kwargs={"kwarg1":1, "kwarg2": 2})
+            "an object with a method 'method5' whose return value when called with (1, 2, kwarg1=1, kwarg2=2) matches 'value1212'",
+            has_return_value(
+                "method5", "value1212", args=[1, 2], kwargs={"kwarg1": 1, "kwarg2": 2}
+            ),
         )
 
     def testDescribeMissingMethod(self):
@@ -201,7 +213,9 @@ class HasReturnValueTest(MatcherTest, ObjectReturnValueMatcher):
     def testReturnValueMismatchWithMultipleArgsAndKwargs(self):
         self.assert_describe_mismatch(
             "method 'method5' called with (1, 2, kwarg1=1, kwarg2=2) was 'value1212'",
-            has_return_value("method5", "not the value", args=[1, 2], kwargs={"kwarg1": 1, "kwarg2": 2}),
+            has_return_value(
+                "method5", "not the value", args=[1, 2], kwargs={"kwarg1": 1, "kwarg2": 2}
+            ),
             MethodsNewStyle(),
         )
 

--- a/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
+++ b/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
@@ -96,7 +96,7 @@ class OverridingNewStyleGetAttribute(object):
         if name == "method2":
             return lambda arg1: "value{}".format(arg1)
         if name == "method3":
-            return lambda kwarg1=None: "value{}".format(, kwarg1)
+            return lambda kwarg1=None: "value{}".format(kwarg1)
         if name == "method4":
             return lambda arg1, kwarg1=None: "value{}{}".format(arg1, kwarg1)
         if name == "method5":

--- a/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
+++ b/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
@@ -21,16 +21,16 @@ class MethodsOldStyle:
         return "value1"
     
     def method2(self, arg1):
-        return f"value{arg1}"
+        return "value{}".format(arg1)
     
     def method3(self, kwarg1=None):
-        return f"value{kwarg1}"
+        return "value{}".format(kwarg1)
 
     def method4(self, arg1, kwarg1=None):
-        return f"value{arg1}{kwarg1}"
+        return "value{}{}".format(arg1, kwarg1)
 
     def method5(self, arg1, arg2, kwarg1=None, kwarg2=None):
-        return f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+        return "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
 
 
 class MethodsNewStyle(object):
@@ -39,16 +39,16 @@ class MethodsNewStyle(object):
         return "value1"
     
     def method2(self, arg1):
-        return f"value{arg1}"
+        return "value{}".format(arg1)
     
     def method3(self, kwarg1=None):
-        return f"value{kwarg1}"
+        return "value{}".format(kwarg1)
 
     def method4(self, arg1, kwarg1=None):
-        return f"value{arg1}{kwarg1}"
+        return "value{}{}".format(arg1, kwarg1)
 
     def method5(self, arg1, arg2, kwarg1=None, kwarg2=None):
-        return f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+        return "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
 
     def __repr__(self):
         return "MethodsNewStyle"
@@ -62,13 +62,13 @@ class OverridingOldStyle:
         if name == "method1":
             return lambda: "value1"
         if name == "method2":
-            return lambda arg1: f"value{arg1}"
+            return lambda arg1: "value{}".format(arg1)
         if name == "method3":
-            return lambda kwarg1=None: f"value{kwarg1}"
+            return lambda kwarg1=None: "value{}".format(kwarg1)
         if name == "method4":
-            return lambda arg1, kwarg1=None: f"value{arg1}{kwarg1}"
+            return lambda arg1, kwarg1=None: "value{}{}".format(arg1, kwarg1)
         if name == "method5":
-            return lambda arg1, arg2, kwarg1=None, kwarg2=None: f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
 
         raise AttributeError(name)
 
@@ -78,13 +78,13 @@ class OverridingNewStyleGetAttr(object):
         if name == "method1":
             return lambda: "value1"
         if name == "method2":
-            return lambda arg1: f"value{arg1}"
+            return lambda arg1: "value{}".format(arg1)
         if name == "method3":
-            return lambda kwarg1=None: f"value{kwarg1}"
+            return lambda kwarg1=None: "value{}".format(kwarg1)
         if name == "method4":
-            return lambda arg1, kwarg1=None: f"value{arg1}{kwarg1}"
+            return lambda arg1, kwarg1=None: "value{}{}".format(arg1, kwarg1)
         if name == "method5":
-            return lambda arg1, arg2, kwarg1=None, kwarg2=None: f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
 
         raise AttributeError(name)
 
@@ -94,13 +94,13 @@ class OverridingNewStyleGetAttribute(object):
         if name == "method1":
             return lambda: "value1"
         if name == "method2":
-            return lambda arg1: f"value{arg1}"
+            return lambda arg1: "value{}".format(arg1)
         if name == "method3":
-            return lambda kwarg1=None: f"value{kwarg1}"
+            return lambda kwarg1=None: "value{}".format(, kwarg1)
         if name == "method4":
-            return lambda arg1, kwarg1=None: f"value{arg1}{kwarg1}"
+            return lambda arg1, kwarg1=None: "value{}{}".format(arg1, kwarg1)
         if name == "method5":
-            return lambda arg1, arg2, kwarg1=None, kwarg2=None: f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: "value{}{}{}{}".format(arg1, arg2, kwarg1, kwarg2)
 
         raise AttributeError(name)
 

--- a/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
+++ b/tests/hamcrest_unit_test/object/hasreturnvalue_test.py
@@ -1,0 +1,222 @@
+if __name__ == "__main__":
+    import sys
+
+    sys.path.insert(0, "..")
+    sys.path.insert(0, "../..")
+
+import unittest
+
+from hamcrest import greater_than
+from hamcrest.library.object.hasreturnvalue import *
+from hamcrest_unit_test.matcher_test import MatcherTest
+
+__author__ = "Chris Rose"
+__copyright__ = "Copyright 2011 hamcrest.org"
+__license__ = "BSD, see License.txt"
+
+
+class MethodsOldStyle:
+
+    def method1(self):
+        return "value1"
+    
+    def method2(self, arg1):
+        return f"value{arg1}"
+    
+    def method3(self, kwarg1=None):
+        return f"value{kwarg1}"
+
+    def method4(self, arg1, kwarg1=None):
+        return f"value{arg1}{kwarg1}"
+
+    def method5(self, arg1, arg2, kwarg1=None, kwarg2=None):
+        return f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+
+
+class MethodsNewStyle(object):
+
+    def method1(self):
+        return "value1"
+    
+    def method2(self, arg1):
+        return f"value{arg1}"
+    
+    def method3(self, kwarg1=None):
+        return f"value{kwarg1}"
+
+    def method4(self, arg1, kwarg1=None):
+        return f"value{arg1}{kwarg1}"
+
+    def method5(self, arg1, arg2, kwarg1=None, kwarg2=None):
+        return f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+
+    def __repr__(self):
+        return "MethodsNewStyle"
+
+    def __str__(self):
+        return repr(self)
+
+
+class OverridingOldStyle:
+    def __getattr__(self, name):
+        if name == "method1":
+            return lambda: "value1"
+        if name == "method2":
+            return lambda arg1: f"value{arg1}"
+        if name == "method3":
+            return lambda kwarg1=None: f"value{kwarg1}"
+        if name == "method4":
+            return lambda arg1, kwarg1=None: f"value{arg1}{kwarg1}"
+        if name == "method5":
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+
+        raise AttributeError(name)
+
+
+class OverridingNewStyleGetAttr(object):
+    def __getattr__(self, name):
+        if name == "method1":
+            return lambda: "value1"
+        if name == "method2":
+            return lambda arg1: f"value{arg1}"
+        if name == "method3":
+            return lambda kwarg1=None: f"value{kwarg1}"
+        if name == "method4":
+            return lambda arg1, kwarg1=None: f"value{arg1}{kwarg1}"
+        if name == "method5":
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+
+        raise AttributeError(name)
+
+
+class OverridingNewStyleGetAttribute(object):
+    def __getattribute__(self, name):
+        if name == "method1":
+            return lambda: "value1"
+        if name == "method2":
+            return lambda arg1: f"value{arg1}"
+        if name == "method3":
+            return lambda kwarg1=None: f"value{kwarg1}"
+        if name == "method4":
+            return lambda arg1, kwarg1=None: f"value{arg1}{kwarg1}"
+        if name == "method5":
+            return lambda arg1, arg2, kwarg1=None, kwarg2=None: f"value{arg1}{arg2}{kwarg1}{kwarg2}"
+
+        raise AttributeError(name)
+
+
+class ObjectReturnValueMatcher(object):
+
+    match_sets = (
+        ("old-style: %s", MethodsOldStyle),
+        ("new-style: %s", MethodsNewStyle),
+        ("old-style, overriding: %s", OverridingOldStyle),
+        ("new-style, using getattr: %s", OverridingNewStyleGetAttr),
+        ("new-style, using getattribute: %s", OverridingNewStyleGetAttribute),
+    )
+
+    def assert_matches_for_all_types(self, description, matcher):
+        for description_fmt, target_class in self.match_sets:
+            self.assert_matches(description_fmt % description, matcher, target_class())
+
+    def assert_does_not_match_for_all_types(self, description, matcher):
+        for description_fmt, target_class in self.match_sets:
+            self.assert_does_not_match(description_fmt % description, matcher, target_class())
+
+
+class HasReturnValueTest(MatcherTest, ObjectReturnValueMatcher):
+    def testHasReturnValueWithoutValueMatcher(self):
+        self.assert_matches_for_all_types("has method with name", has_return_value("method1"))
+
+    def testHasReturnValueWithoutValueMatcherNegative(self):
+        self.assert_does_not_match_for_all_types(
+            "has method with name", has_return_value("not_there")
+        )
+
+    def testHasReturnValueWithValueMatcher(self):
+        self.assert_matches_for_all_types(
+            "has method with name and value", has_return_value("method1", "value1")
+        )
+
+    def testHasReturnValueWithValueMatcherNegative(self):
+        self.assert_does_not_match_for_all_types(
+            "has method with name", has_return_value("method1", "not the value")
+        )
+
+    def testDescription(self):
+        self.assert_description(
+            "an object with a method 'method1' whose return value when called with () matches not None", has_return_value("method1")
+        )
+        self.assert_description(
+            "an object with a method 'method1' whose return value when called with () matches 'value1'", has_return_value("method1", "value1")
+        )
+        self.assert_description(
+            "an object with a method 'method2' whose return value when called with (1) matches 'value1'", has_return_value("method2", "value1", args=[1])
+        )
+        self.assert_description(
+            "an object with a method 'method3' whose return value when called with (kwarg1=1) matches 'value1'", has_return_value("method3", "value1", kwargs={"kwarg1": 1})
+        )
+        self.assert_description(
+            "an object with a method 'method4' whose return value when called with (1, kwarg1=1) matches 'value11'", has_return_value("method4", "value11", args=[1], kwargs={"kwarg1": 1})
+        )
+        self.assert_description(
+            "an object with a method 'method5' whose return value when called with (1, 2, kwarg1=1, kwarg2=2) matches 'value1212'", has_return_value("method5", "value1212", args=[1, 2], kwargs={"kwarg1":1, "kwarg2": 2})
+        )
+
+    def testDescribeMissingMethod(self):
+        self.assert_mismatch_description(
+            "<MethodsNewStyle> did not have a 'not_there' method",
+            has_return_value("not_there"),
+            MethodsNewStyle(),
+        )
+
+    def testDescribeReturnValueMismatch(self):
+        self.assert_mismatch_description(
+            "method 'method1' called with () was 'value1'",
+            has_return_value("method1", "another_value"),
+            MethodsNewStyle(),
+        )
+
+    def testReturnValueMismatchWithOneArg(self):
+        self.assert_describe_mismatch(
+            "method 'method2' called with (1) was 'value1'",
+            has_return_value("method2", "not the value", args=["1"]),
+            MethodsNewStyle(),
+        )
+
+    def testReturnValueMismatchWithOneKwarg(self):
+        self.assert_describe_mismatch(
+            "method 'method3' called with (kwarg1=1) was 'value1'",
+            has_return_value("method3", "not the value", kwargs={"kwarg1": 1}),
+            MethodsNewStyle(),
+        )
+
+    def testReturnValueMismatchWithOneArgAndOneKwarg(self):
+        self.assert_describe_mismatch(
+            "method 'method4' called with (1, kwarg1=1) was 'value11'",
+            has_return_value("method4", "not the value", args=[1], kwargs={"kwarg1": 1}),
+            MethodsNewStyle(),
+        )
+
+    def testReturnValueMismatchWithMultipleArgsAndKwargs(self):
+        self.assert_describe_mismatch(
+            "method 'method5' called with (1, 2, kwarg1=1, kwarg2=2) was 'value1212'",
+            has_return_value("method5", "not the value", args=[1, 2], kwargs={"kwarg1": 1, "kwarg2": 2}),
+            MethodsNewStyle(),
+        )
+
+    def testMismatchDescription(self):
+        self.assert_describe_mismatch(
+            "<MethodsNewStyle> did not have a 'not_there' method",
+            has_return_value("not_there"),
+            MethodsNewStyle(),
+        )
+
+    def testNoMismatchDescriptionOnMatch(self):
+        self.assert_no_mismatch_description(
+            has_return_value("method1", "value1"), MethodsNewStyle()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hello, maintainers of PyHamcrest! Long-time admirer, first time pull-requester.

This new matcher will match against the return value of an object's method.
In the world of web automation, this matcher will be particularly useful to
test for things like whether an element is displayed by matching against its
`is_displayed()` method return value, or checking class strings, or any number
of things an automated tester might need to check.

I've already created a version of this matcher locally in a test suite that's using 
my ScreenPy library, but i think the work i did there would be useful to others
in this more generalized form.

I tried my best to follow the conventions i saw elsewhere in this codebase. 
Please let me know if i've left something out or am not following the 
conventions correctly—i am happy to make any changes you might want!