### PR TITLE
Proposal for improved safety of assert_that

### DIFF
--- a/src/hamcrest/core/string_description.py
+++ b/src/hamcrest/core/string_description.py
@@ -25,11 +25,11 @@ class StringDescription(BaseDescription):
     """
 
     def __init__(self) -> None:
-        self.out = ""
+        self.out = []
 
     def __str__(self) -> str:
         """Returns the description."""
-        return self.out
+        return ''.join(self.out)
 
     def append(self, string: str) -> None:
-        self.out += str(string)
+        self.out.append(str(string))


### PR DESCRIPTION
Alternative for #148 and #147 that more specifically targets usage patterns that are highly likely to be mistakes.