### PR TITLE
Fix numpy testing being missed

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ looponfailroots =
 # Keep docs in sync with docs env and .readthedocs.yml.
 [gh-actions]
 python =
-    3.6: py36, py36-numpy
+    3.6: py36
     3.7: py37, docs
     3.8: py38, lint, manifest, typing, changelog
     3.9: py39
@@ -21,7 +21,7 @@ python =
 
 
 [tox]
-envlist = typing,lint,py36,py37,py38,py39,pypy,pypy3,manifest,docs,pypi-description,changelog,coverage-report
+envlist = typing,lint,py36,py36-numpy,py37,py38,py39,pypy,pypy3,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
 
 


### PR DESCRIPTION
Adds py36-numpy to the envlist, which should result in it being built