### PR TITLE
Improve string representation of matcher in allure report

### DIFF
--- a/changelog.d/170.feature.rst
+++ b/changelog.d/170.feature.rst
@@ -1,0 +1,1 @@
+* Add pretty string representation for matchers objects

--- a/src/hamcrest/core/base_matcher.py
+++ b/src/hamcrest/core/base_matcher.py
@@ -1,3 +1,4 @@
+from textwrap import shorten
 from typing import Optional, TypeVar
 
 from hamcrest.core.description import Description
@@ -24,6 +25,12 @@ class BaseMatcher(Matcher[T]):
 
     def __str__(self) -> str:
         return tostring(self)
+
+    def __repr__(self) -> str:
+        """Returns matcher string representation."""
+        return "<{0}({1})>".format(
+            self.__class__.__name__, shorten(tostring(self), 60, placeholder="...")
+        )
 
     def _matches(self, item: T) -> bool:
         raise NotImplementedError("_matches")

--- a/src/hamcrest/core/string_description.py
+++ b/src/hamcrest/core/string_description.py
@@ -1,4 +1,5 @@
 from hamcrest.core.selfdescribing import SelfDescribing
+from textwrap import shorten
 
 from .base_description import BaseDescription
 
@@ -32,8 +33,8 @@ class StringDescription(BaseDescription):
         return self.out
 
     def __repr__(self) -> str:
-        """Returns the description."""
-        return self.out
+        """Returns the object string representation."""
+        return "<{0}({1})>".format(self.__class__.__name__, shorten(self.out, 60, placeholder="..."))
 
     def append(self, string: str) -> None:
         self.out += str(string)

--- a/src/hamcrest/core/string_description.py
+++ b/src/hamcrest/core/string_description.py
@@ -1,5 +1,4 @@
 from hamcrest.core.selfdescribing import SelfDescribing
-from textwrap import shorten
 
 from .base_description import BaseDescription
 
@@ -31,10 +30,6 @@ class StringDescription(BaseDescription):
     def __str__(self) -> str:
         """Returns the description."""
         return self.out
-
-    def __repr__(self) -> str:
-        """Returns the object string representation."""
-        return "<{0}({1})>".format(self.__class__.__name__, shorten(self.out, 60, placeholder="..."))
 
     def append(self, string: str) -> None:
         self.out += str(string)

--- a/src/hamcrest/core/string_description.py
+++ b/src/hamcrest/core/string_description.py
@@ -31,5 +31,9 @@ class StringDescription(BaseDescription):
         """Returns the description."""
         return self.out
 
+    def __repr__(self) -> str:
+        """Returns the description."""
+        return self.out
+
     def append(self, string: str) -> None:
         self.out += str(string)

--- a/tests/hamcrest_unit_test/base_matcher_test.py
+++ b/tests/hamcrest_unit_test/base_matcher_test.py
@@ -37,6 +37,19 @@ class BaseMatcherTest(unittest.TestCase):
     def testMatchDescriptionShouldDescribeItem(self):
         assert_match_description("was <99>", PassingBaseMatcher(), 99)
 
+    def testMatcherReprShouldDescribeMatcher(self):
+        assert repr(FailingBaseMatcher()) == "<FailingBaseMatcher(SOME DESCRIPTION)>"
+
+    def testMatcherReprShouldTruncateLongDescription(self):
+        class LongDescriptionMatcher(BaseMatcher):
+            def describe_to(self, description):
+                description.append_text("1234 " * 13)
+
+        assert (
+            repr(LongDescriptionMatcher())
+            == "<LongDescriptionMatcher(1234 1234 1234 1234 1234 1234 1234 1234 1234 1234 1234...)>"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Matchers in allure report now look like:
<hamcrest.core.core.isnot.IsNot object at 0x7f7262d17c40>

PR purpose:
Make it look more pretty