### PR TITLE
Fix typing target in build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -141,7 +141,9 @@ commands = towncrier --draft
 
 [testenv:typing]
 basepython = python3.9
-deps = mypy
+deps =
+    mypy
+    types-mock
 commands =
     mypy src/
 


### PR DESCRIPTION
As of [mypy version 0.900](http://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html), type stubs for 3rd party libraries are not automatically installed, so we have to do so explicitly.