### PR TITLE
Fix is_() type annotations.

### DIFF
--- a/src/hamcrest/core/core/is_.py
+++ b/src/hamcrest/core/core/is_.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, TypeVar, Union, overload
+from typing import Optional, Type, TypeVar, overload, Any
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
@@ -46,12 +46,17 @@ def _wrap_value_or_type(x):
 
 
 @overload
-def is_(x: Type) -> Matcher[object]:
+def is_(x: Type) -> Matcher[Any]:
     ...
 
 
 @overload
-def is_(x: Union[Matcher[T], T]) -> Matcher[T]:
+def is_(x: Matcher[T]) -> Matcher[T]:
+    ...
+
+
+@overload
+def is_(x: T) -> Matcher[T]:
     ...
 
 

--- a/tests/type-hinting/test_test_types.yml
+++ b/tests/type-hinting/test_test_types.yml
@@ -2,4 +2,4 @@
   main: |
     from hamcrest.library.text.isequal_ignoring_case import equal_to_ignoring_case
 
-    reveal_type(equal_to_ignoring_case(""))  # N: Revealed type is 'hamcrest.core.matcher.Matcher[builtins.str]'
+    reveal_type(equal_to_ignoring_case(""))  # N: Revealed type is "hamcrest.core.matcher.Matcher[builtins.str]"


### PR DESCRIPTION
Fis the `is_()` type hint issue shown by #178 and #179.