### PR TITLE
fix(typing): Added __all__ to package root

### DIFF
--- a/src/hamcrest/__init__.py
+++ b/src/hamcrest/__init__.py
@@ -1,7 +1,13 @@
 from hamcrest.core import *
+from hamcrest.core import __all__ as _core_vars
 from hamcrest.library import *
+from hamcrest.library import __all__ as _library_vars
 
 __version__ = "2.0.3.dev0"
 __author__ = "Chris Rose"
 __copyright__ = "Copyright 2020 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = []
+__all__.extend(_core_vars)
+__all__.extend(_library_vars)

--- a/src/hamcrest/__init__.py
+++ b/src/hamcrest/__init__.py
@@ -1,7 +1,6 @@
 from hamcrest.core import *
-from hamcrest.core import __all__ as _core_vars
 from hamcrest.library import *
-from hamcrest.library import __all__ as _library_vars
+from hamcrest import core, library
 
 __version__ = "2.0.3.dev0"
 __author__ = "Chris Rose"
@@ -9,5 +8,5 @@ __copyright__ = "Copyright 2020 hamcrest.org"
 __license__ = "BSD, see License.txt"
 
 __all__ = []
-__all__.extend(_core_vars)
-__all__.extend(_library_vars)
+__all__.extend(core.__all__)
+__all__.extend(library.__all__)

--- a/src/hamcrest/core/__init__.py
+++ b/src/hamcrest/core/__init__.py
@@ -4,3 +4,21 @@ from hamcrest.core.core import *
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = [
+    "assert_that",
+    "all_of",
+    "any_of",
+    "anything",
+    "calling",
+    "described_as",
+    "equal_to",
+    "instance_of",
+    "is_",
+    "is_not",
+    "none",
+    "not_",
+    "not_none",
+    "raises",
+    "same_instance",
+]

--- a/src/hamcrest/core/core/__init__.py
+++ b/src/hamcrest/core/core/__init__.py
@@ -15,3 +15,20 @@ from hamcrest.core.core.raises import calling, raises
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = [
+    "all_of",
+    "any_of",
+    "anything",
+    "calling",
+    "described_as",
+    "equal_to",
+    "instance_of",
+    "is_",
+    "is_not",
+    "none",
+    "not_",
+    "not_none",
+    "raises",
+    "same_instance",
+]

--- a/src/hamcrest/library/collection/__init__.py
+++ b/src/hamcrest/library/collection/__init__.py
@@ -13,3 +13,18 @@ from .issequence_onlycontaining import only_contains
 __author__ = "Chris Rose"
 __copyright__ = "Copyright 2013 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = [
+    "contains",
+    "contains_exactly",
+    "contains_inanyorder",
+    "empty",
+    "has_entries",
+    "has_entry",
+    "has_item",
+    "has_items",
+    "has_key",
+    "has_value",
+    "is_in",
+    "only_contains",
+]


### PR DESCRIPTION
This PR adds missing `__all__` in package root, core and library.

After adding this, pyright correctly recognizes all imports.

I tried to minimize names duplication, and used `__all__.extend` syntax where possible. (This is valid option, as explained here https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface).

But it doesn't seem to work recursively, so we can use it only once per import hierarchy.


Closes #175