### PR TITLE
chore: Add missing __all__ to library submodules

### DIFF
--- a/changelog.d/175.misc.rst
+++ b/changelog.d/175.misc.rst
@@ -1,0 +1,1 @@
+* Add missing __all__ to library submodules (fixes pyright type checking)

--- a/src/hamcrest/library/integration/__init__.py
+++ b/src/hamcrest/library/integration/__init__.py
@@ -5,3 +5,5 @@ from .match_equality import match_equality
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = ["match_equality"]

--- a/src/hamcrest/library/number/__init__.py
+++ b/src/hamcrest/library/number/__init__.py
@@ -11,3 +11,11 @@ from .ordering_comparison import (
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = [
+    "close_to",
+    "greater_than",
+    "greater_than_or_equal_to",
+    "less_than",
+    "less_than_or_equal_to",
+]

--- a/src/hamcrest/library/object/__init__.py
+++ b/src/hamcrest/library/object/__init__.py
@@ -7,3 +7,10 @@ from .hasstring import has_string
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = [
+    "has_length",
+    "has_properties",
+    "has_property",
+    "has_string",
+]

--- a/src/hamcrest/library/text/__init__.py
+++ b/src/hamcrest/library/text/__init__.py
@@ -11,3 +11,13 @@ from .stringstartswith import starts_with
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
 __license__ = "BSD, see License.txt"
+
+__all__ = [
+    "contains_string",
+    "ends_with",
+    "equal_to_ignoring_case",
+    "equal_to_ignoring_whitespace",
+    "matches_regexp",
+    "starts_with",
+    "string_contains_in_order",
+]


### PR DESCRIPTION
I found few more missing `__all__`, causing errors like this:

```
... error: "matches_regexp" is not exported from module "hamcrest.library.text"
... Import from "hamcrest.library.text.stringmatches" instead (reportPrivateImportUsage)
```