### PR TITLE
Ordered comparison matchers should fail for incomparable types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           - "3.9"
           - "3.10.0"
           - "pypy2"
-          - "pypy3"
+          - "pypy-3.7"
         exclude:
           - os: macos-latest
             python-version: pypy3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
         # args: ["-l100"]
@@ -26,7 +26,7 @@ repos:
           )
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
         # args: ["-l100"]

--- a/src/hamcrest/library/number/ordering_comparison.py
+++ b/src/hamcrest/library/number/ordering_comparison.py
@@ -22,7 +22,10 @@ class OrderingComparison(BaseMatcher[Any]):
         self.comparison_description = comparison_description
 
     def _matches(self, item: Any) -> bool:
-        return self.comparison_function(item, self.value)
+        try:
+            return self.comparison_function(item, self.value)
+        except TypeError:
+            return False
 
     def describe_to(self, description: Description) -> None:
         description.append_text("a value ").append_text(self.comparison_description).append_text(

--- a/tests/hamcrest_unit_test/collection/issequence_containinginanyorder_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_containinginanyorder_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from hamcrest import greater_than
 from hamcrest.core.core.isequal import equal_to
 from hamcrest.library.collection.issequence_containinginanyorder import contains_inanyorder
 from hamcrest_unit_test.matcher_test import MatcherTest
@@ -82,6 +83,16 @@ class IsSequenceContainingInAnyOrderBase(object):
         matcher.matches(self._sequence(3, 1))
         self.assert_describe_mismatch(
             "no item matches: <2> in [<3>, <1>]", matcher, self._sequence(3, 1)
+        )
+
+    def testIncomparableTypes(self):
+        self.assert_matches("Incomparable types", contains_inanyorder(*[4, "a"]), ["a", 4])
+
+    def testIncomparableTypesInNestedMatcher(self):
+        self.assert_matches(
+            "Incomparable types in nested matcher",
+            contains_inanyorder(*[greater_than(0), "a"]),
+            ["a", 4],
         )
 
 

--- a/tests/hamcrest_unit_test/number/ordering_comparison_test.py
+++ b/tests/hamcrest_unit_test/number/ordering_comparison_test.py
@@ -67,6 +67,9 @@ class OrderingComparisonTest(MatcherTest):
         self.assert_describe_mismatch("was <0>", greater_than_or_equal_to(1), 0)
         self.assert_describe_mismatch("was <2>", less_than_or_equal_to(1), 2)
 
+    def testIncomparableTypes(self):
+        self.assert_does_not_match("incomparable types", greater_than(1), "a")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Ordered comparison matchers should fail for incomparable types, not throw a TypeError. Fix for #185