### PR TITLE
2.0.3+ is no longer compatible with Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ params = dict(
     provides=["hamcrest"],
     long_description=read("README.rst"),
     long_description_content_type="text/x-rst",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[],
     extras_require={
         "docs": REQUIREMENTS_DOCS,


### PR DESCRIPTION
Variable annotations were only introduced in Python 3.6, so 2.0.3+ no longer compiles on Python 3.5