### PR TITLE
Add a release workflow based on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+on:
+  push:
+    tags:
+      - V*
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  pure-python-wheel-and-sdist:
+    name: Build a pure Python wheel and source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Fetch all tags
+          fetch-depth: 0
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade build
+
+      - name: Build
+        run: python -m build
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs:
+      - pure-python-wheel-and-sdist
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: dist
+
+      - name: Push build artifacts to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          skip_existing: true
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: "https://test.pypi.org/legacy/"


### PR DESCRIPTION
Depends on hatch-scm to perform the versioning

* runs full suite of tests
* releases the current tag

Only set up for test PyPi right now; once this is verified working,
we'll switch to release PyPi