### PR TITLE
deprecated numpy alias

### DIFF
--- a/tests/hamcrest_unit_test/number/iscloseto_test.py
+++ b/tests/hamcrest_unit_test/number/iscloseto_test.py
@@ -64,7 +64,7 @@ except ImportError:
 class IsNumericTest(unittest.TestCase):
     @unittest.skipUnless(NUMPY_AVAILABLE, "Skipped because it needs NumPy")
     def test_numpy_numeric_type_int(self):
-        self.assertTrue(isnumeric(np.int(1)), "Platform integer (normally either int32 or int64)")
+        self.assertTrue(isnumeric(np.int_(1)), "Platform integer (normally either int32 or int64)")
 
     @unittest.skipUnless(NUMPY_AVAILABLE, "Skipped because it needs NumPy")
     def test_numpy_numeric_type_int8(self):
@@ -102,7 +102,7 @@ class IsNumericTest(unittest.TestCase):
 
     @unittest.skipUnless(NUMPY_AVAILABLE, "Skipped because it needs NumPy")
     def test_numpy_numeric_type_float(self):
-        self.assertTrue(isnumeric(np.float(1)), "Shorthand for float64.")
+        self.assertTrue(isnumeric(np.float_(1)), "Shorthand for float64.")
 
     @unittest.skipUnless(NUMPY_AVAILABLE, "Skipped because it needs NumPy")
     def test_numpy_numeric_type_float16(self):
@@ -127,7 +127,7 @@ class IsNumericTest(unittest.TestCase):
 
     @unittest.skipUnless(NUMPY_AVAILABLE, "Skipped because it needs NumPy")
     def test_numpy_numeric_type_complex(self):
-        self.assertTrue(isnumeric(np.complex(1)), "Shorthand for complex128.")
+        self.assertTrue(isnumeric(np.complex_(1)), "Shorthand for complex128.")
 
     @unittest.skipUnless(NUMPY_AVAILABLE, "Skipped because it needs NumPy")
     def test_numpy_numeric_type_complex64(self):


### PR DESCRIPTION
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated