### PR TITLE
Fix breakages due to Mypy chages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/src/hamcrest/library/collection/isdict_containing.py
+++ b/src/hamcrest/library/collection/isdict_containing.py
@@ -52,7 +52,7 @@ class IsDictContaining(BaseMatcher[Mapping[K, V]]):
         else:
             super().describe_match(item, match_description)
 
-    def _matching_keys(self, item):
+    def _matching_keys(self, item) -> MutableMapping[K, V]:
         key_matches: MutableMapping[K, V] = {}
         if hasmethod(item, "items"):
             for key, value in item.items():

--- a/tests/type-hinting/core/core/test_is.yml
+++ b/tests/type-hinting/core/core/test_is.yml
@@ -9,4 +9,4 @@
     b = 99
 
     assert_that(a, is_(empty()))
-    assert_that(b, is_(empty()))  # E: Cannot infer type argument 1 of "assert_that"
+    assert_that(b, is_(empty()))  # E: Cannot infer type argument 1 of "assert_that"  [misc]

--- a/tests/type-hinting/core/test_assert_that.yml
+++ b/tests/type-hinting/core/test_assert_that.yml
@@ -8,4 +8,4 @@
     assert_that("str", instance_of(str))
     assert_that(99, starts_with("str"))
   out: |
-    main:5: error: Cannot infer type argument 1 of "assert_that"
+    main:5: error: Cannot infer type argument 1 of "assert_that"  [misc]

--- a/tests/type-hinting/library/collection/test_empty.yml
+++ b/tests/type-hinting/library/collection/test_empty.yml
@@ -5,4 +5,4 @@
     from hamcrest import assert_that, is_, empty
 
     assert_that([], empty())
-    assert_that(99, empty())  # E: Cannot infer type argument 1 of "assert_that"
+    assert_that(99, empty())  # E: Cannot infer type argument 1 of "assert_that"  [misc]

--- a/tests/type-hinting/library/text/test_equal_to_ignoring_case.yml
+++ b/tests/type-hinting/library/text/test_equal_to_ignoring_case.yml
@@ -9,4 +9,4 @@
     equal_to_ignoring_case(99)
   out: |
     main:3: note: Revealed type is "hamcrest.core.matcher.Matcher[builtins.str]"
-    main:5: error: Argument 1 to "equal_to_ignoring_case" has incompatible type "int"; expected "str"
+    main:5: error: Argument 1 to "equal_to_ignoring_case" has incompatible type "int"; expected "str"  [arg-type]


### PR DESCRIPTION
Mypy 0.990 has been released, and it appears that some of the error messages have changed somewhat, which breaks our build. I've changed some tests to reflect the changes, hopefully fixing #220.

One useful thing, too - the new mypy pointed out an unannotated function, albeit an internal one.