### PR TITLE
Add explicit installation instruction example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,12 @@ Hamcrest can be installed using the usual Python packaging tools. It depends on
 distribute, but as long as you have a network connection when you install, the
 installation process will take care of that for you.
 
+For example:
+
+.. code::
+
+ pip install PyHamcrest
+
 My first PyHamcrest test
 ========================
 


### PR DESCRIPTION
The package name is not clear- it's installed `PyHamcrest` but imported as `hamcrest`. There's no consistency in the Python world on this, so we may as well have an explicit example in the instructions showing the package installation name.