### PR TITLE
Better handling for exception messages with special characters

### DIFF
--- a/src/hamcrest/core/core/raises.py
+++ b/src/hamcrest/core/core/raises.py
@@ -41,7 +41,8 @@ class Raises(BaseMatcher[Callable[..., Any]]):
 
             if isinstance(self.actual, self.expected):
                 if self.pattern is not None:
-                    if re.search(self.pattern, str(self.actual)) is None:
+                    if (re.search(self.pattern, str(self.actual)) is None
+                            and self.pattern is not str(self.actual)):
                         return False
                 if self.matcher is not None:
                     if not self.matcher.matches(self.actual):

--- a/tests/hamcrest_unit_test/core/raises_with_parens_test.py
+++ b/tests/hamcrest_unit_test/core/raises_with_parens_test.py
@@ -1,0 +1,24 @@
+import unittest
+
+from hamcrest import assert_that, calling, raises
+
+
+def raise_error(msg):
+    raise AssertionError(msg)
+
+
+class ParensTest(unittest.TestCase):
+
+    def test_literal_parens(self):
+
+        message = 'Message with (parens)'
+        assert_that(
+            calling(raise_error).with_args(message),
+            raises(AssertionError, message)
+        )
+
+    def test_parens_in_regex(self):
+        assert_that(
+            calling(raise_error).with_args('abab'),
+            raises(AssertionError, r'(ab)+')
+        )


### PR DESCRIPTION
 raises(Error, "message with (parens)") no longer fails with an exact match


````
def raise_error():
    raise AssertionError("Message with  (parens)")

assert_that(calling(raise_error),  raises(AssertionError, "Message with (parens)")
```
will fail with `Correct assertion type raised, but the expected pattern ("Message with (parens)") not found. Exception message was: "Message with (parens)"` which is a somewhat confusing message.

This is because the parens in the pattern are treated as a regex group and need to be escaped.

This pull request removes this source of potential confusion. The above code will now not error as a regex mismatch will only happen if the pattern does not match as a regex AND it is not a literal match for the error.
