### PR TITLE
The release workflow should only run for tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,6 @@ on:
   push:
     tags:
       - V*
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
   release:


### PR DESCRIPTION
Is this right? I wouldn't expect this workflow to run for all pushes to main, let alone for pull requests.