### PR TITLE
Add has_getter() and has_getters() object matchers, based on has_property()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ doc/_build/
 htmlcov/
 src/hamcrest/_version.py
 .tool-versions
+venv

--- a/src/hamcrest/library/object/hasgetter.py
+++ b/src/hamcrest/library/object/hasgetter.py
@@ -58,9 +58,9 @@ class IsObjectWithGetter(BaseMatcher[object]):
             ).append_description_of(self.property_name).append_text(" is not callable")
             return
 
-        mismatch_description.append_text("result of getter ").append_description_of(
+        mismatch_description.append_text("getter ").append_description_of(
             self.property_name
-        ).append_text(" expected to return ")
+        ).append_text(" return value ")
         value = getter()
         self.value_matcher.describe_mismatch(value, mismatch_description)
 

--- a/src/hamcrest/library/object/hasgetter.py
+++ b/src/hamcrest/library/object/hasgetter.py
@@ -1,0 +1,215 @@
+from typing import Any, Mapping, TypeVar, Union, overload
+
+from hamcrest import described_as
+from hamcrest.core import anything
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.core.allof import AllOf
+from hamcrest.core.description import Description
+from hamcrest.core.helpers.wrap_matcher import wrap_matcher as wrap_shortcut
+from hamcrest.core.matcher import Matcher
+from hamcrest.core.string_description import StringDescription
+
+__author__ = "Chris Rose;Thomas Hess"
+__copyright__ = "Copyright 2011-2024 hamcrest.org"
+__license__ = "BSD, see License.txt"
+
+V = TypeVar("V")
+
+
+class IsObjectWithGetter(BaseMatcher[object]):
+    def __init__(self, property_name: str, value_matcher: Matcher[V]) -> None:
+        self.property_name = property_name
+        self.value_matcher = value_matcher
+
+    def _matches(self, item: object) -> bool:
+        if item is None:
+            return False
+
+        if not hasattr(item, self.property_name):
+            return False
+
+        getter = getattr(item, self.property_name)
+        if not callable(getter):
+            return False
+
+        value = getter()
+        return self.value_matcher.matches(value)
+
+    def describe_to(self, description: Description) -> None:
+        description.append_text("an object with a getter '").append_text(
+            self.property_name
+        ).append_text("' returning ").append_description_of(self.value_matcher)
+
+    def describe_mismatch(self, item: object, mismatch_description: Description) -> None:
+        if item is None:
+            mismatch_description.append_text("was None")
+            return
+
+        if not hasattr(item, self.property_name):
+            mismatch_description.append_description_of(item).append_text(
+                " did not have the "
+            ).append_description_of(self.property_name).append_text(" getter")
+            return
+
+        getter = getattr(item, self.property_name)
+        if not callable(getter):
+            mismatch_description.append_description_of(item).append_text(
+                " attribute "
+            ).append_description_of(self.property_name).append_text(" is not callable")
+            return
+
+        mismatch_description.append_text("result of getter ").append_description_of(
+            self.property_name
+        ).append_text(" expected to return ")
+        value = getter()
+        self.value_matcher.describe_mismatch(value, mismatch_description)
+
+    def __str__(self):
+        d = StringDescription()
+        self.describe_to(d)
+        return str(d)
+
+
+def has_getter(name: str, match: Union[None, Matcher[V], V] = None) -> Matcher[object]:
+    """Matches if object has a callable getter with a given name whose return value satisfies
+    a given matcher.
+
+    :param name: The name of the getter.
+    :param match: Optional matcher to satisfy.
+
+    This matcher determines if the evaluated object has a callable getter with a given
+    name. If no such getter is found or the found attribute is not callable,
+    ``has_getter`` is not satisfied.
+
+    If the getter is found and is callable, its return value is passed to a given matcher for
+    evaluation. If the ``match`` argument is not a matcher, it is implicitly
+    wrapped in an :py:func:`~hamcrest.core.core.isequal.equal_to` matcher to
+    check for equality.
+
+    If the ``match`` argument is not provided, the
+    :py:func:`~hamcrest.core.core.isanything.anything` matcher is used so that
+    ``has_getter`` is satisfied if a matching getter is found.
+
+    Examples::
+
+        has_getter('name', starts_with('J'))
+        has_getter('name', 'Jon')
+        has_getter('name')
+
+    """
+
+    if match is None:
+        match = anything()
+
+    return IsObjectWithGetter(name, wrap_shortcut(match))
+
+
+# Keyword argument form
+@overload
+def has_getters(**keys_valuematchers: Union[Matcher[V], V]) -> Matcher[Any]:
+    ...
+
+
+# Name to matcher dict form
+@overload
+def has_getters(keys_valuematchers: Mapping[str, Union[Matcher[V], V]]) -> Matcher[Any]:
+    ...
+
+
+# Alternating name/matcher form
+@overload
+def has_getters(*keys_valuematchers: Any) -> Matcher[Any]:
+    ...
+
+
+def has_getters(*keys_valuematchers, **kv_args):
+    """Matches if an object has callable getters satisfying all of a dictionary
+    of string getter names and corresponding value matchers.
+
+    :param keys_valuematchers: A dictionary mapping keys to associated value matchers,
+        or to expected values for
+        :py:func:`~hamcrest.core.core.isequal.equal_to` matching.
+
+    Note that the keys must be actual keys, not matchers. Any value argument
+    that is not a matcher is implicitly wrapped in an
+    :py:func:`~hamcrest.core.core.isequal.equal_to` matcher to check for
+    equality.
+
+    Examples::
+
+        has_getters({'foo':equal_to(1), 'bar':equal_to(2)})
+        has_getters({'foo':1, 'bar':2})
+        has_getters({'x':  1, 'y':  2, 'area': less_than(100), 'height': greater_than(5)})
+
+    ``has_getters`` also accepts a list of keyword arguments:
+
+    .. function:: has_getters(keyword1=value_matcher1[, keyword2=value_matcher2[, ...]])
+
+    :param keyword1: A keyword to look up.
+    :param valueMatcher1: The matcher to satisfy for the value, or an expected
+        value for :py:func:`~hamcrest.core.core.isequal.equal_to` matching.
+
+    Examples::
+
+        has_getters(foo=equal_to(1), bar=equal_to(2))
+        has_getters(foo=1, bar=2)
+
+    Finally, ``has_getters`` also accepts a list of alternating keys and their
+    value matchers:
+
+    .. function:: has_getters(key1, value_matcher1[, ...])
+
+    :param key1: A key (not a matcher) to look up.
+    :param valueMatcher1: The matcher to satisfy for the value, or an expected
+        value for :py:func:`~hamcrest.core.core.isequal.equal_to` matching.
+
+    Examples::
+
+        has_getters('foo', equal_to(1), 'bar', equal_to(2))
+        has_getters('foo', 1, 'bar', 2)
+
+    """
+    if len(keys_valuematchers) == 1:
+        try:
+            base_dict = keys_valuematchers[0].copy()
+            for key in base_dict:
+                base_dict[key] = wrap_shortcut(base_dict[key])
+        except AttributeError:
+            raise ValueError(
+                "single-argument calls to has_getters must pass a dict as the argument"
+            )
+    else:
+        if len(keys_valuematchers) % 2:
+            raise ValueError("has_getters requires key-value pairs")
+        base_dict = {}
+        for index in range(int(len(keys_valuematchers) / 2)):
+            base_dict[keys_valuematchers[2 * index]] = wrap_shortcut(
+                keys_valuematchers[2 * index + 1]
+            )
+
+    for key, value in kv_args.items():
+        base_dict[key] = wrap_shortcut(value)
+
+    if len(base_dict) > 1:
+        description = StringDescription().append_text("an object with getters ")
+        for i, (property_name, property_value_matcher) in enumerate(sorted(base_dict.items())):
+            description.append_description_of(property_name).append_text(
+                " returning "
+            ).append_description_of(property_value_matcher)
+            if i < len(base_dict) - 1:
+                description.append_text(" and ")
+
+        return described_as(
+            str(description),
+            AllOf(
+                *[
+                    has_getter(property_name, property_value_matcher)
+                    for property_name, property_value_matcher in sorted(base_dict.items())
+                ],
+                describe_all_mismatches=True,
+                describe_matcher_in_mismatch=False,
+            ),
+        )
+    else:
+        property_name, property_value_matcher = base_dict.popitem()
+        return has_getter(property_name, property_value_matcher)

--- a/src/hamcrest/library/object/hasgetter.py
+++ b/src/hamcrest/library/object/hasgetter.py
@@ -70,7 +70,7 @@ class IsObjectWithGetter(BaseMatcher[object]):
         return str(d)
 
 
-def has_getter(name: str, match: Union[None, Matcher[V], V] = None) -> Matcher[object]:
+def has_getter(name: str, match: Union[None, Matcher[V], V] = None) -> Matcher[Any]:
     """Matches if object has a callable getter with a given name whose return value satisfies
     a given matcher.
 
@@ -122,7 +122,7 @@ def has_getters(*keys_valuematchers: Any) -> Matcher[Any]:
     ...
 
 
-def has_getters(*keys_valuematchers, **kv_args):
+def has_getters(*keys_valuematchers, **kv_args) -> Matcher[Any]:
     """Matches if an object has callable getters satisfying all of a dictionary
     of string getter names and corresponding value matchers.
 

--- a/tests/hamcrest_unit_test/object/hasgetter_test.py
+++ b/tests/hamcrest_unit_test/object/hasgetter_test.py
@@ -1,0 +1,175 @@
+import typing
+
+if __name__ == "__main__":
+    import sys
+
+    sys.path.insert(0, "..")
+    sys.path.insert(0, "../..")
+
+import unittest
+
+from hamcrest import greater_than
+from hamcrest.library.object.hasgetter import has_getters, has_getter
+from hamcrest_unit_test.matcher_test import MatcherTest
+
+__author__ = "Chris Rose;Thomas Hess"
+__copyright__ = "Copyright 2024 hamcrest.org"
+__license__ = "BSD, see License.txt"
+
+
+class StaticMethodGetter:
+    @staticmethod
+    def field() -> str:
+        return "value"
+
+    @staticmethod
+    def field2() -> str:
+        return "value2"
+
+
+class NonCallableProperty:
+    field = "value"
+
+
+class MethodGetter:
+    def field(self) -> str:
+        return "value"
+
+    def field2(self) -> str:
+        return "value2"
+
+    def field3(self) -> str:
+        return "value3"
+
+    def __repr__(self):
+        return "ThreePropertiesNewStyle"
+
+    def __str__(self):
+        return repr(self)
+
+
+class OverridingGetAttr:
+    def __getattr__(self, name):
+        if name == "field":
+            return lambda: "value"
+        if name == "field2":
+            return lambda: "value2"
+
+        raise AttributeError(name)
+
+
+class OverridingGetAttribute:
+    def __getattribute__(self, name):
+        if name == "field":
+            return lambda: "value"
+        if name == "field2":
+            return lambda: "value2"
+
+        raise AttributeError(name)
+
+
+class ObjectPropertyMatcher(object):
+    match_sets: typing.Tuple[typing.Tuple[str, typing.Type]] = (
+        ("static-method: {}", StaticMethodGetter),
+        ("method: {}", MethodGetter),
+        ("using getattr: {}", OverridingGetAttr),
+        ("using getattribute: {}", OverridingGetAttribute),
+    )
+
+    def assert_matches_for_all_types(self, description, matcher):
+        for description_fmt, target_class in self.match_sets:
+            self.assert_matches(description_fmt.format(description), matcher, target_class())
+
+    def assert_does_not_match_for_all_types(self, description, matcher):
+        for description_fmt, target_class in self.match_sets:
+            self.assert_does_not_match(description_fmt.format(description), matcher, target_class())
+
+
+class HasPropertyTest(MatcherTest, ObjectPropertyMatcher):
+    def testHasPropertyWithoutValueMatcher(self):
+        self.assert_matches_for_all_types("has getter with name", has_getter("field"))
+
+    def testHasPropertyWithoutValueMatcherNegative(self):
+        self.assert_does_not_match_for_all_types(
+            "has getter with name", has_getter("not_there")
+        )
+
+    def testHasPropertyWithValueMatcher(self):
+        self.assert_matches_for_all_types(
+            "has getter with name and value", has_getter("field", "value")
+        )
+
+    def testHasPropertyWithValueMatcherNegative(self):
+        self.assert_does_not_match_for_all_types(
+            "has getter with name", has_getter("field", "not the value")
+        )
+
+    def testDescription(self):
+        self.assert_description(
+            "an object with a getter 'field' returning ANYTHING", has_getter("field")
+        )
+        self.assert_description(
+            "an object with a getter 'field' returning 'value'", has_getter("field", "value")
+        )
+
+    def testDescribeMissingProperty(self):
+        self.assert_mismatch_description(
+            "<ThreePropertiesNewStyle> did not have the 'not_there' getter",
+            has_getter("not_there"),
+            MethodGetter(),
+        )
+
+    def testDescribePropertyValueMismatch(self):
+        self.assert_mismatch_description(
+            "getter 'field' return value was 'value'",
+            has_getter("field", "another_value"),
+            MethodGetter(),
+        )
+
+    def testMismatchDescription(self):
+        self.assert_describe_mismatch(
+            "<ThreePropertiesNewStyle> did not have the 'not_there' getter",
+            has_getter("not_there"),
+            MethodGetter(),
+        )
+
+    def testNoMismatchDescriptionOnMatch(self):
+        self.assert_no_mismatch_description(
+            has_getter("field", "value"), MethodGetter()
+        )
+
+
+class HasPropertiesTest(MatcherTest, ObjectPropertyMatcher):
+    def testMatcherCreationRequiresEvenNumberOfPositionalArguments(self):
+        self.assertRaises(ValueError, has_getters, "a", "b", "c")
+
+    def testMatchesUsingSingleDictionaryArgument(self):
+        # import pdb; pdb.set_trace()
+        self.assert_matches_for_all_types(
+            "matches using a single-argument dictionary",
+            has_getters({"field": "value", "field2": "value2"}),
+        )
+
+    def testMatchesUsingKeywordArguments(self):
+        self.assert_matches_for_all_types(
+            "matches using a kwarg dict", has_getters(field="value", field2="value2")
+        )
+
+    def testMismatchDescription(self):
+        self.assert_describe_mismatch(
+            "getter 'field' return value was 'value' and getter 'field3' return value was 'value3'",
+            has_getters(field="different", field2="value2", field3="alsodifferent"),
+            MethodGetter(),
+        )
+
+    def testDescription(self):
+        self.assert_description("an object with a getter 'a' returning <1>", has_getters(a=1))
+        self.assert_description(
+            "an object with getters 'a' returning <1> "
+            "and 'b' returning a value greater than <2>",
+            has_getters(a=1, b=greater_than(2)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds two new matchers, `has_getter(name, matcher)` and `has_getters(dict[str, matcher])` and overloads, similar to `has_property()` and `has_properties()`.

In fact, I forked the property matchers to create the getter matchers.

## Use case

There matchers are meant for objects that expose properties via callable getter methods. Prominent examples are the Qt GUI toolkit wrappers PyQt and PySide. The Qt objects expose properties via getter/setter pairs, and the Python wrappers translate them 1:1.
Have a look at [QRectF](https://doc.qt.io/qt-6/qrectf.html) implementing a floating point rectangle, and [QPointF](https://doc.qt.io/qt-6/qpointf.html). Object dimensions, coordinates and similar are accessible via getter methods.

The addition of has_getter() allows matching against those as if they were plain Python properties.
```python
rect = QRectF(0, 1, 10, 11)  # x, y, width, height
assert_that(
    rect, has_getters({
        "topLeft":  has_getters({  # These return a QPointF
            "x": close_to(0),
            "y": close_to(1),}),
        "bottomRight":  has_getters({
            "x": close_to(10),
            "y": close_to(12),}),
        "width": close_to(10),
        "height": close_to(11),
        "isEmpty": False,
})
```