### PR TITLE
Replace "Sequence" annotations by "Iterable"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,15 +140,15 @@ PyHamcrest comes with a library of useful matchers:
   * ``anything`` - match anything, useful in composite matchers when you don't care about a particular value
   * ``is_not``, ``not_`` - negate the matcher
 
-* Sequence
+* Iterable
 
-  * ``contains`` - exactly match the entire sequence
-  * ``contains_inanyorder`` - match the entire sequence, but in any order
-  * ``has_item`` - match if given item appears in the sequence
-  * ``has_items`` - match if all given items appear in the sequence, in any order
-  * ``is_in`` - match if item appears in the given sequence
-  * ``only_contains`` - match if sequence's items appear in given list
-  * ``empty`` - match if the sequence is empty
+  * ``contains`` - exactly match the entire iterable
+  * ``contains_inanyorder`` - match the entire iterable, but in any order
+  * ``has_item`` - match if given item appears in the iterable
+  * ``has_items`` - match if all given items appear in the iterable, in any order
+  * ``is_in`` - match if item appears in the given iterable
+  * ``only_contains`` - match if iterable's items appear in given list
+  * ``empty`` - match if the iterable is empty
 
 * Dictionary
 
@@ -166,7 +166,7 @@ PyHamcrest comes with a library of useful matchers:
 
 The arguments for many of these matchers accept not just a matching value, but
 another matcher, so matchers can be composed for greater flexibility. For
-example, ``only_contains(less_than(5))`` will match any sequence where every
+example, ``only_contains(less_than(5))`` will match any iterable where every
 item is less than 5.
 
 

--- a/doc/matcher_internals/sequence_matchers.rst
+++ b/doc/matcher_internals/sequence_matchers.rst
@@ -1,14 +1,14 @@
-.. _sequence-matcher-internals:
+.. _iterable-matcher-internals:
 
-Sequence Matchers
+Iterable Matchers
 -----------------
 
-Matchers of sequences.
+Matchers of iterables.
 
 
-.. automodule:: hamcrest.library.collection.issequence_containinginorder
-.. automodule:: hamcrest.library.collection.issequence_containinginanyorder
-.. automodule:: hamcrest.library.collection.issequence_containing
+.. automodule:: hamcrest.library.collection.isiterable_containinginorder
+.. automodule:: hamcrest.library.collection.isiterable_containinginanyorder
+.. automodule:: hamcrest.library.collection.isiterable_containing
 .. automodule:: hamcrest.library.collection.isin
-.. automodule:: hamcrest.library.collection.issequence_onlycontaining
+.. automodule:: hamcrest.library.collection.isiterable_onlycontaining
 .. automodule:: hamcrest.library.collection.is_empty

--- a/doc/matcher_library/sequence_matchers.rst
+++ b/doc/matcher_library/sequence_matchers.rst
@@ -1,27 +1,27 @@
-Sequence Matchers
+Iterable Matchers
 -----------------
 
-Matchers of sequences.
+Matchers of iterables.
 
-See also, :ref:`Sequence matcher internals<sequence-matcher-internals>`.
+See also, :ref:`Iterable matcher internals<iterable-matcher-internals>`.
 
 
 contains_exactly
 ^^^^^^^^^^^^^^^^
 
-.. currentmodule:: hamcrest.library.collection.issequence_containinginorder
+.. currentmodule:: hamcrest.library.collection.isiterable_containinginorder
 .. autofunction:: contains_exactly
 
 contains_inanyorder
 ^^^^^^^^^^^^^^^^^^^
 
-.. currentmodule:: hamcrest.library.collection.issequence_containinginanyorder
+.. currentmodule:: hamcrest.library.collection.isiterable_containinginanyorder
 .. autofunction:: contains_inanyorder
 
 has_item, has_items
 ^^^^^^^^^^^^^^^^^^^
 
-.. currentmodule:: hamcrest.library.collection.issequence_containing
+.. currentmodule:: hamcrest.library.collection.isiterable_containing
 .. autofunction:: has_items
 
 is_in
@@ -33,7 +33,7 @@ is_in
 only_contains
 ^^^^^^^^^^^^^
 
-.. currentmodule:: hamcrest.library.collection.issequence_onlycontaining
+.. currentmodule:: hamcrest.library.collection.isiterable_onlycontaining
 .. autofunction:: only_contains
 
 empty

--- a/src/hamcrest/core/core/raises.py
+++ b/src/hamcrest/core/core/raises.py
@@ -121,7 +121,7 @@ class DeferredCallable(object):
     def __call__(self):
         self.func(*self.args, **self.kwargs)
 
-    def with_args(self, *args, **kwargs):
+    def with_args(self, *args: Any, **kwargs: Any):
         self.args = args
         self.kwargs = kwargs
         return self

--- a/src/hamcrest/library/collection/__init__.py
+++ b/src/hamcrest/library/collection/__init__.py
@@ -5,10 +5,10 @@ from .isdict_containingentries import has_entries
 from .isdict_containingkey import has_key
 from .isdict_containingvalue import has_value
 from .isin import is_in
-from .issequence_containing import has_item, has_items
-from .issequence_containinginanyorder import contains_inanyorder
-from .issequence_containinginorder import contains, contains_exactly
-from .issequence_onlycontaining import only_contains
+from .isiterable_containing import has_item, has_items
+from .isiterable_containinginanyorder import contains_inanyorder
+from .isiterable_containinginorder import contains, contains_exactly
+from .isiterable_onlycontaining import only_contains
 
 __author__ = "Chris Rose"
 __copyright__ = "Copyright 2013 hamcrest.org"

--- a/src/hamcrest/library/collection/isin.py
+++ b/src/hamcrest/library/collection/isin.py
@@ -1,4 +1,4 @@
-from typing import Sequence, TypeVar
+from typing import Iterable, TypeVar
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
@@ -12,8 +12,8 @@ T = TypeVar("T")
 
 
 class IsIn(BaseMatcher[T]):
-    def __init__(self, sequence: Sequence[T]) -> None:
-        self.sequence = sequence
+    def __init__(self, sequence: Iterable[T]) -> None:
+        self.sequence = tuple(sequence)
 
     def _matches(self, item: T) -> bool:
         return item in self.sequence
@@ -22,7 +22,7 @@ class IsIn(BaseMatcher[T]):
         description.append_text("one of ").append_list("(", ", ", ")", self.sequence)
 
 
-def is_in(sequence: Sequence[T]) -> Matcher[T]:
+def is_in(sequence: Iterable[T]) -> Matcher[T]:
     """Matches if evaluated object is present in a given sequence.
 
     :param sequence: The sequence to search.

--- a/src/hamcrest/library/collection/isiterable_containing.py
+++ b/src/hamcrest/library/collection/isiterable_containing.py
@@ -1,4 +1,4 @@
-from typing import Sequence, TypeVar, Union, cast
+from typing import Iterable, TypeVar, Union, cast
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.core.allof import all_of
@@ -13,11 +13,11 @@ __license__ = "BSD, see License.txt"
 T = TypeVar("T")
 
 
-class IsSequenceContaining(BaseMatcher[Sequence[T]]):
+class IsIterableContaining(BaseMatcher[Iterable[T]]):
     def __init__(self, element_matcher: Matcher[T]) -> None:
         self.element_matcher = element_matcher
 
-    def _matches(self, item: Sequence[T]) -> bool:
+    def _matches(self, item: Iterable[T]) -> bool:
         try:
             for element in item:
                 if self.element_matcher.matches(element):
@@ -36,25 +36,25 @@ class IsSequenceContaining(BaseMatcher[Sequence[T]]):
 # be seeing a one-time sequence here (like a generator); see issue #20
 # Instead, we wrap it inside a class that will convert the sequence into
 # a concrete list and then hand it off to the all_of matcher.
-class IsSequenceContainingEvery(BaseMatcher[Sequence[T]]):
+class IsIterableContainingEvery(BaseMatcher[Iterable[T]]):
     def __init__(self, *element_matchers: Matcher[T]) -> None:
-        delegates = [cast(Matcher[Sequence[T]], has_item(e)) for e in element_matchers]
-        self.matcher: Matcher[Sequence[T]] = all_of(*delegates)
+        delegates = [cast(Matcher[Iterable[T]], has_item(e)) for e in element_matchers]
+        self.matcher: Matcher[Iterable[T]] = all_of(*delegates)
 
-    def _matches(self, item: Sequence[T]) -> bool:
+    def _matches(self, item: Iterable[T]) -> bool:
         try:
             return self.matcher.matches(list(item))
         except TypeError:
             return False
 
-    def describe_mismatch(self, item: Sequence[T], mismatch_description: Description) -> None:
+    def describe_mismatch(self, item: Iterable[T], mismatch_description: Description) -> None:
         self.matcher.describe_mismatch(item, mismatch_description)
 
     def describe_to(self, description: Description) -> None:
         self.matcher.describe_to(description)
 
 
-def has_item(match: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
+def has_item(match: Union[Matcher[T], T]) -> Matcher[Iterable[T]]:
     """Matches if any element of sequence satisfies a given matcher.
 
     :param match: The matcher to satisfy, or an expected value for
@@ -69,10 +69,10 @@ def has_item(match: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     equality.
 
     """
-    return IsSequenceContaining(wrap_matcher(match))
+    return IsIterableContaining(wrap_matcher(match))
 
 
-def has_items(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
+def has_items(*items: Union[Matcher[T], T]) -> Matcher[Iterable[T]]:
     """Matches if all of the given matchers are satisfied by any elements of
     the sequence.
 
@@ -90,4 +90,4 @@ def has_items(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     matchers = []
     for item in items:
         matchers.append(wrap_matcher(item))
-    return IsSequenceContainingEvery(*matchers)
+    return IsIterableContainingEvery(*matchers)

--- a/src/hamcrest/library/collection/isiterable_containinginanyorder.py
+++ b/src/hamcrest/library/collection/isiterable_containinginanyorder.py
@@ -1,4 +1,4 @@
-from typing import MutableSequence, Optional, Sequence, TypeVar, Union, cast
+from typing import Iterable, Optional, TypeVar, Union
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
@@ -14,15 +14,15 @@ T = TypeVar("T")
 
 class MatchInAnyOrder(object):
     def __init__(
-        self, matchers: Sequence[Matcher[T]], mismatch_description: Optional[Description]
+        self, matchers: Iterable[Matcher[T]], mismatch_description: Optional[Description]
     ) -> None:
-        self.matchers = cast(MutableSequence[Matcher[T]], matchers[:])
+        self.matchers = list(matchers)
         self.mismatch_description = mismatch_description
 
     def matches(self, item: T) -> bool:
         return self.isnotsurplus(item) and self.ismatched(item)
 
-    def isfinished(self, item: Sequence[T]) -> bool:
+    def isfinished(self, item: Iterable[T]) -> bool:
         if not self.matchers:
             return True
         if self.mismatch_description:
@@ -49,12 +49,12 @@ class MatchInAnyOrder(object):
         return False
 
 
-class IsSequenceContainingInAnyOrder(BaseMatcher[Sequence[T]]):
-    def __init__(self, matchers: Sequence[Matcher[T]]) -> None:
+class IsIterableContainingInAnyOrder(BaseMatcher[Iterable[T]]):
+    def __init__(self, matchers: Iterable[Matcher[T]]) -> None:
         self.matchers = matchers
 
     def matches(
-        self, item: Sequence[T], mismatch_description: Optional[Description] = None
+        self, item: Iterable[T], mismatch_description: Optional[Description] = None
     ) -> bool:
         try:
             sequence = list(item)
@@ -65,12 +65,12 @@ class IsSequenceContainingInAnyOrder(BaseMatcher[Sequence[T]]):
             return matchsequence.isfinished(sequence)
         except TypeError:
             if mismatch_description:
-                super(IsSequenceContainingInAnyOrder, self).describe_mismatch(
+                super(IsIterableContainingInAnyOrder, self).describe_mismatch(
                     item, mismatch_description
                 )
             return False
 
-    def describe_mismatch(self, item: Sequence[T], mismatch_description: Description) -> None:
+    def describe_mismatch(self, item: Iterable[T], mismatch_description: Description) -> None:
         self.matches(item, mismatch_description)
 
     def describe_to(self, description: Description) -> None:
@@ -79,7 +79,7 @@ class IsSequenceContainingInAnyOrder(BaseMatcher[Sequence[T]]):
         ).append_text(" in any order")
 
 
-def contains_inanyorder(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
+def contains_inanyorder(*items: Union[Matcher[T], T]) -> Matcher[Iterable[T]]:
     """Matches if sequences's elements, in any order, satisfy a given list of
     matchers.
 
@@ -100,4 +100,4 @@ def contains_inanyorder(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     matchers = []
     for item in items:
         matchers.append(wrap_matcher(item))
-    return IsSequenceContainingInAnyOrder(matchers)
+    return IsIterableContainingInAnyOrder(matchers)

--- a/src/hamcrest/library/collection/isiterable_containinginorder.py
+++ b/src/hamcrest/library/collection/isiterable_containinginorder.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Sequence, TypeVar, Union
+from typing import Iterable, Optional, TypeVar, Union
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
@@ -15,9 +15,9 @@ T = TypeVar("T")
 
 class MatchingInOrder(object):
     def __init__(
-        self, matchers: Sequence[Matcher[T]], mismatch_description: Optional[Description]
+        self, matchers: Iterable[Matcher[T]], mismatch_description: Optional[Description]
     ) -> None:
-        self.matchers = matchers
+        self.matchers = tuple(matchers)
         self.mismatch_description = mismatch_description
         self.next_match_index = 0
 
@@ -51,12 +51,12 @@ class MatchingInOrder(object):
         return True
 
 
-class IsSequenceContainingInOrder(BaseMatcher[Sequence[T]]):
-    def __init__(self, matchers: Sequence[Matcher[T]]) -> None:
+class IsIterableContainingInOrder(BaseMatcher[Iterable[T]]):
+    def __init__(self, matchers: Iterable[Matcher[T]]) -> None:
         self.matchers = matchers
 
     def matches(
-        self, item: Sequence[T], mismatch_description: Optional[Description] = None
+        self, item: Iterable[T], mismatch_description: Optional[Description] = None
     ) -> bool:
         try:
             matchsequence = MatchingInOrder(self.matchers, mismatch_description)
@@ -66,19 +66,19 @@ class IsSequenceContainingInOrder(BaseMatcher[Sequence[T]]):
             return matchsequence.isfinished()
         except TypeError:
             if mismatch_description:
-                super(IsSequenceContainingInOrder, self).describe_mismatch(
+                super(IsIterableContainingInOrder, self).describe_mismatch(
                     item, mismatch_description
                 )
             return False
 
-    def describe_mismatch(self, item: Sequence[T], mismatch_description: Description) -> None:
+    def describe_mismatch(self, item: Iterable[T], mismatch_description: Description) -> None:
         self.matches(item, mismatch_description)
 
     def describe_to(self, description: Description) -> None:
         description.append_text("a sequence containing ").append_list("[", ", ", "]", self.matchers)
 
 
-def contains_exactly(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
+def contains_exactly(*items: Union[Matcher[T], T]) -> Matcher[Iterable[T]]:
     """Matches if sequence's elements satisfy a given list of matchers, in order.
 
     :param match1,...: A comma-separated list of matchers.
@@ -94,10 +94,10 @@ def contains_exactly(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     matchers = []
     for item in items:
         matchers.append(wrap_matcher(item))
-    return IsSequenceContainingInOrder(matchers)
+    return IsIterableContainingInOrder(matchers)
 
 
-def contains(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
+def contains(*items: Union[Matcher[T], T]) -> Matcher[Iterable[T]]:
     """Deprecated - use contains_exactly(*items)"""
     warnings.warn("deprecated - use contains_exactly(*items)", DeprecationWarning)
     return contains_exactly(*items)

--- a/src/hamcrest/library/collection/isiterable_onlycontaining.py
+++ b/src/hamcrest/library/collection/isiterable_onlycontaining.py
@@ -1,4 +1,4 @@
-from typing import Sequence, TypeVar, Union
+from typing import Iterable, TypeVar, Union
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.core.anyof import any_of
@@ -13,11 +13,11 @@ __license__ = "BSD, see License.txt"
 T = TypeVar("T")
 
 
-class IsSequenceOnlyContaining(BaseMatcher[Sequence[T]]):
+class IsIterableOnlyContaining(BaseMatcher[Iterable[T]]):
     def __init__(self, matcher: Matcher[T]) -> None:
         self.matcher = matcher
 
-    def _matches(self, item: Sequence[T]) -> bool:
+    def _matches(self, item: Iterable[T]) -> bool:
         try:
             sequence = list(item)
             if len(sequence) == 0:
@@ -35,7 +35,7 @@ class IsSequenceOnlyContaining(BaseMatcher[Sequence[T]]):
         )
 
 
-def only_contains(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
+def only_contains(*items: Union[Matcher[T], T]) -> Matcher[Iterable[T]]:
     """Matches if each element of sequence satisfies any of the given matchers.
 
     :param match1,...: A comma-separated list of matchers.
@@ -57,4 +57,4 @@ def only_contains(*items: Union[Matcher[T], T]) -> Matcher[Sequence[T]]:
     matchers = []
     for item in items:
         matchers.append(wrap_matcher(item))
-    return IsSequenceOnlyContaining(any_of(*matchers))
+    return IsIterableOnlyContaining(any_of(*matchers))

--- a/tests/hamcrest_unit_test/collection/issequence_containing_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_containing_test.py
@@ -1,11 +1,11 @@
 import unittest
 
 from hamcrest.core.core.isequal import equal_to
-from hamcrest.library.collection.issequence_containing import has_item, has_items
+from hamcrest.library.collection.isiterable_containing import has_item, has_items
 from hamcrest_unit_test.matcher_test import MatcherTest
 
 from .quasisequence import QuasiSequence
-from .sequencemixin import GeneratorForm, SequenceForm
+from .sequencemixin import CollectionForm, GeneratorForm, SequenceForm
 
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
@@ -50,6 +50,10 @@ class IsConcreteSequenceContaining(MatcherTest, SequenceForm, IsSequenceContaini
 
 
 class IsGeneratorContaining(MatcherTest, GeneratorForm, IsSequenceContainingTestBase):
+    pass
+
+
+class IsCollectionContaining(MatcherTest, CollectionForm, IsSequenceContainingTestBase):
     pass
 
 
@@ -110,6 +114,12 @@ class IsConcreteSequenceContainingItemsTest(
 
 class IsGeneratorSequenceContainingItemsTest(
     MatcherTest, IsSequenceContainingItemsTestBase, GeneratorForm
+):
+    pass
+
+
+class IsCollectionContainingItemsTest(
+    MatcherTest, IsSequenceContainingItemsTestBase, CollectionForm
 ):
     pass
 

--- a/tests/hamcrest_unit_test/collection/issequence_containinginanyorder_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_containinginanyorder_test.py
@@ -2,11 +2,11 @@ import unittest
 
 from hamcrest import greater_than
 from hamcrest.core.core.isequal import equal_to
-from hamcrest.library.collection.issequence_containinginanyorder import contains_inanyorder
+from hamcrest.library.collection.isiterable_containinginanyorder import contains_inanyorder
 from hamcrest_unit_test.matcher_test import MatcherTest
 
 from .quasisequence import QuasiSequence
-from .sequencemixin import GeneratorForm, SequenceForm
+from .sequencemixin import CollectionForm, GeneratorForm, SequenceForm
 
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
@@ -79,10 +79,8 @@ class IsSequenceContainingInAnyOrderBase(object):
         self.assert_describe_mismatch("was <3>", contains_inanyorder(1, 2), 3)
 
     def testDescribeMismatchAfterMatch(self):
-        matcher = contains_inanyorder(1, 2, 3)
-        matcher.matches(self._sequence(3, 1))
         self.assert_describe_mismatch(
-            "no item matches: <2> in [<3>, <1>]", matcher, self._sequence(3, 1)
+            "no item matches: <2> in [<3>, <1>]", contains_inanyorder(1, 2, 3), self._sequence(3, 1)
         )
 
     def testIncomparableTypes(self):
@@ -104,6 +102,12 @@ class IsConcreteSequenceContainingInAnyOrderTest(
 
 class IsGeneratorSequenceContainingInAnyOrderTest(
     MatcherTest, IsSequenceContainingInAnyOrderBase, GeneratorForm
+):
+    pass
+
+
+class IsCollectionContainingInAnyOrderTest(
+    MatcherTest, IsSequenceContainingInAnyOrderBase, CollectionForm
 ):
     pass
 

--- a/tests/hamcrest_unit_test/collection/issequence_containinginorder_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_containinginorder_test.py
@@ -1,11 +1,11 @@
 import unittest
 
 from hamcrest.core.core.isequal import equal_to
-from hamcrest.library.collection.issequence_containinginorder import contains, contains_exactly
+from hamcrest.library.collection.isiterable_containinginorder import contains, contains_exactly
 from hamcrest_unit_test.matcher_test import MatcherTest
 
 from .quasisequence import QuasiSequence
-from .sequencemixin import GeneratorForm, SequenceForm
+from .sequencemixin import CollectionForm, GeneratorForm, SequenceForm
 
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
@@ -85,6 +85,12 @@ class IsConcreteSequenceContainingInOrderTest(
 
 class IsGeneratorSequenceContainingInOrderTest(
     MatcherTest, IsSequenceContainingInOrderTestBase, GeneratorForm
+):
+    pass
+
+
+class IsCollectionContainingInOrderTest(
+    MatcherTest, IsSequenceContainingInOrderTestBase, CollectionForm
 ):
     pass
 

--- a/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
@@ -1,12 +1,12 @@
 import unittest
 
 from hamcrest.core.core.isequal import equal_to
-from hamcrest.library.collection.issequence_onlycontaining import only_contains
+from hamcrest.library.collection.isiterable_onlycontaining import only_contains
 from hamcrest.library.number.ordering_comparison import less_than
 from hamcrest_unit_test.matcher_test import MatcherTest
 
 from .quasisequence import QuasiSequence
-from .sequencemixin import GeneratorForm, SequenceForm
+from .sequencemixin import CollectionForm, GeneratorForm, SequenceForm
 
 __author__ = "Jon Reid"
 __copyright__ = "Copyright 2011 hamcrest.org"
@@ -73,6 +73,12 @@ class IsConcreteSequenceOnlyContainingTest(
 
 class IsGeneratorSequenceOnlyContainingTest(
     MatcherTest, IsSequenceOnlyContainingTestBase, GeneratorForm
+):
+    pass
+
+
+class IsCollectionOnlyContainingTest(
+    MatcherTest, IsSequenceOnlyContainingTestBase, CollectionForm
 ):
     pass
 

--- a/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
+++ b/tests/hamcrest_unit_test/collection/issequence_onlycontaining_test.py
@@ -77,9 +77,7 @@ class IsGeneratorSequenceOnlyContainingTest(
     pass
 
 
-class IsCollectionOnlyContainingTest(
-    MatcherTest, IsSequenceOnlyContainingTestBase, CollectionForm
-):
+class IsCollectionOnlyContainingTest(MatcherTest, IsSequenceOnlyContainingTestBase, CollectionForm):
     pass
 
 

--- a/tests/hamcrest_unit_test/collection/sequencemixin.py
+++ b/tests/hamcrest_unit_test/collection/sequencemixin.py
@@ -7,3 +7,8 @@ class GeneratorForm(object):
 class SequenceForm(object):
     def _sequence(self, *objects):
         return list(objects)
+
+
+class CollectionForm(object):
+    def _sequence(self, *objects):
+        return {obj: 0 for obj in objects}


### PR DESCRIPTION
I have seen that `Sequence` annotations could be replaced by `Iterable` making the range of accepted types wider

In order to improve type annotations, I `Sequence` annotations can be replaced by `Iterable`. This would make all these methods available for `dict`, `set` or `Generator`, for example, with static type checking.

This is backwards compatible and just tests to check methods with dictionary as a `Collection` example where added.