### PR TITLE
Update Python version support to 3.10-3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,22 +18,22 @@ jobs:
     name: "Python ${{ matrix.python-version }} / ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
     env:
-      USING_COVERAGE: "3.8,3.9,3.10,3.11,3.12"
+      USING_COVERAGE: "3.10,3.11,3.12,3.13,3.14"
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
-          - "pypy3.9"
+          - "3.13"
+          - "3.14"
+          - "pypy3.11"
         exclude:
           - os: macos-latest
-            python-version: pypy3.9
+            python-version: pypy3.11
 
     steps:
       - uses: actions/checkout@v4

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
   os: ubuntu-22.04
   tools:
     # Keep version in sync with tox.ini (docs and gh-actions).
-    python: "3.12"
+    python: "3.14"
 
 sphinx:
   configuration: doc/conf.py

--- a/changelog.d/272.misc.rst
+++ b/changelog.d/272.misc.rst
@@ -1,0 +1,1 @@
+Update Python version support to 3.10-3.14 and PyPy 3.11. Drop Python 3.8/3.9 support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "PyHamcrest"
 description = "Hamcrest framework for matcher objects"
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 license = "BSD-3-Clause"
 license-files = ["LICENSE.txt"]
 keywords = [
@@ -31,11 +31,11 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: Jython",
   "Programming Language :: Python :: Implementation :: PyPy",
@@ -46,7 +46,7 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-docs = ["sphinx~=5.0", "alabaster~=0.7"]
+docs = ["sphinx~=7.0", "alabaster~=0.7"]
 tests = [
   "pytest>=5.0",
   "pytest-sugar",

--- a/src/hamcrest/core/core/future.py
+++ b/src/hamcrest/core/core/future.py
@@ -1,4 +1,3 @@
-import sys
 import re
 import asyncio
 from typing import (
@@ -19,14 +18,8 @@ __license__ = "BSD, see License.txt"
 
 T = TypeVar("T")
 
-if sys.version_info > (3, 9):
-    # Same as used in typeshed for asyncio.ensure_future
-    FutureT = asyncio.Future[T]
-    FutureLike = Union[asyncio.Future[T], Awaitable[T]]
-else:
-    # Future is not a parametrised type in earlier version of python
-    FutureT = asyncio.Future
-    FutureLike = Union[asyncio.Future, Awaitable]
+FutureT = asyncio.Future[T]
+FutureLike = Union[asyncio.Future[T], Awaitable[T]]
 
 
 class FutureRaising(BaseMatcher[asyncio.Future]):

--- a/tox.ini
+++ b/tox.ini
@@ -13,16 +13,16 @@ looponfailroots =
 # Keep docs in sync with docs env and .readthedocs.yml.
 [gh]
 python =
-    3.8 = py38, py38-numpy
-    3.9 = py39, py39-numpy
     3.10 = py310, py310-numpy
     3.11 = py311, py311-numpy
-    3.12 = py312, py312-numpy, lint, changelog, typing, docs
-    pypy3.9 = pypy3
+    3.12 = py312, py312-numpy
+    3.13 = py313, py313-numpy
+    3.14 = py314, py314-numpy, lint, changelog, typing, docs
+    pypy3.11 = pypy3
 
 
 [tox]
-envlist = typing,lint,py38{,-numpy},py39{,-numpy},py310{,-numpy},py311{,-numpy},py312{,-numpy},pypy{,-numpy},pypy3{,-numpy},docs,pypi-description,changelog,coverage-report
+envlist = typing,lint,py310{,-numpy},py311{,-numpy},py312{,-numpy},py313{,-numpy},py314{,-numpy},pypy{,-numpy},pypy3{,-numpy},docs,pypi-description,changelog,coverage-report
 isolated_build = True
 
 
@@ -32,16 +32,6 @@ isolated_build = True
 setenv =
     VIRTUALENV_NO_DOWNLOAD=1
 extras = {env:TOX_AP_TEST_EXTRAS:tests}
-commands = python -m pytest {posargs}
-
-
-[testenv:py38-numpy]
-extras = tests-numpy
-commands = python -m pytest {posargs}
-
-
-[testenv:py39-numpy]
-extras = tests-numpy
 commands = python -m pytest {posargs}
 
 
@@ -60,24 +50,14 @@ extras = tests-numpy
 commands = python -m pytest {posargs}
 
 
-[testenv:py38]
-# Python 3.6+ has a number of compile-time warnings on invalid string escapes.
-# PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
-basepython = python3.8
-setenv =
-    PYTHONWARNINGS=d
-extras = {env:TOX_AP_TEST_EXTRAS:tests}
-commands = coverage run -m pytest {posargs}
+[testenv:py313-numpy]
+extras = tests-numpy
+commands = python -m pytest {posargs}
 
 
-[testenv:py39]
-# Python 3.6+ has a number of compile-time warnings on invalid string escapes.
-# PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
-basepython = python3.9
-setenv =
-    PYTHONWARNINGS=d
-extras = {env:TOX_AP_TEST_EXTRAS:tests}
-commands = coverage run -m pytest {posargs}
+[testenv:py314-numpy]
+extras = tests-numpy
+commands = python -m pytest {posargs}
 
 
 [testenv:py310]
@@ -110,8 +90,28 @@ extras = {env:TOX_AP_TEST_EXTRAS:tests}
 commands = coverage run -m pytest {posargs}
 
 
+[testenv:py313]
+# Python 3.6+ has a number of compile-time warnings on invalid string escapes.
+# PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
+basepython = python3.13
+setenv =
+    PYTHONWARNINGS=d
+extras = {env:TOX_AP_TEST_EXTRAS:tests}
+commands = coverage run -m pytest {posargs}
+
+
+[testenv:py314]
+# Python 3.6+ has a number of compile-time warnings on invalid string escapes.
+# PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
+basepython = python3.14
+setenv =
+    PYTHONWARNINGS=d
+extras = {env:TOX_AP_TEST_EXTRAS:tests}
+commands = coverage run -m pytest {posargs}
+
+
 [testenv:coverage-report]
-basepython = python3.12
+basepython = python3.14
 skip_install = true
 deps = coverage[toml]>=5.0.2
 commands =
@@ -120,7 +120,7 @@ commands =
 
 
 [testenv:lint]
-basepython = python3.12
+basepython = python3.14
 skip_install = true
 deps =
     pre-commit
@@ -131,14 +131,14 @@ commands =
 
 [testenv:docs]
 # Keep basepython in sync with gh-actions and .readthedocs.yml.
-basepython = python3.12
+basepython = python3.14
 extras = docs
 commands =
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees doc doc/_build/html
 
 
 [testenv:pypi-description]
-basepython = python3.12
+basepython = python3.14
 skip_install = true
 deps =
     twine
@@ -149,7 +149,7 @@ commands =
 
 
 [testenv:changelog]
-basepython = python3.12
+basepython = python3.14
 deps = 
     towncrier
 skip_install = true
@@ -157,7 +157,7 @@ commands = towncrier --draft
 
 
 [testenv:typing]
-basepython = python3.12
+basepython = python3.14
 deps =
     mypy <= 1.10.1
     types-mock


### PR DESCRIPTION
## Summary
Update Python version support from 3.8-3.12 to 3.10-3.14, dropping support for Python 3.8 and 3.9 while adding support for Python 3.13 and 3.14.

## Changes
- **Python versions**: Updated minimum from 3.8 to 3.10, added support for 3.13 and 3.14
- **PyPy**: Updated from PyPy 3.9 to PyPy 3.11 to align with supported Python versions
- **Sphinx**: Upgraded from ~=5.0 to ~=7.0 for Python 3.13+ compatibility (Python 3.13 removed the `imghdr` module used by Sphinx 5.x)
- **CI/CD**: Updated GitHub Actions matrix and tox environments to test new Python versions
- **Development tools**: Moved linting, typing, and docs generation to Python 3.14
- **Code simplification**: Removed Python 3.9 compatibility code in `future.py` type annotations

## Testing
All environments pass locally:
- ✅ Type checking (`mypy`)
- ✅ Linting and formatting (pre-commit hooks)
- ✅ Documentation build with Sphinx 7.0 on Python 3.14
- ✅ Package validation

CI will verify tests pass across all supported Python versions (3.10-3.14) and PyPy 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)