### PR TITLE
Fix has_entries() crash with non-sortable dictionary keys

### DIFF
--- a/src/hamcrest/library/collection/isdict_containingentries.py
+++ b/src/hamcrest/library/collection/isdict_containingentries.py
@@ -15,7 +15,7 @@ V = TypeVar("V")
 
 class IsDictContainingEntries(BaseMatcher[Mapping[K, V]]):
     def __init__(self, value_matchers) -> None:
-        self.value_matchers = sorted(value_matchers.items())
+        self.value_matchers = list(value_matchers.items())
 
     def _not_a_dictionary(
         self, item: Mapping[K, V], mismatch_description: Optional[Description]

--- a/tests/hamcrest_unit_test/collection/isdict_containingentries_test.py
+++ b/tests/hamcrest_unit_test/collection/isdict_containingentries_test.py
@@ -107,6 +107,27 @@ class IsDictContainingEntriesTest(MatcherTest):
     def testDescribeMismatchOfDictionaryWithNonMatchingValue(self):
         self.assert_describe_mismatch("value for 'a' was <2>", has_entries("a", 1), {"a": 2})
 
+    def testHasEntriesWithNonSortableKeys(self):
+        # Regression: has_entries must not crash for keys that do not support
+        # comparison (<) since the internal sorted() call fails with TypeError.
+        # See: https://github.com/hamcrest/PyHamcrest/issues/271
+
+        class NonComparable:
+            def __init__(self, val):
+                self.val = val
+
+            def __hash__(self):
+                return hash(self.val)
+
+            def __eq__(self, other):
+                return isinstance(other, NonComparable) and self.val == other.val
+
+        k1, k2 = NonComparable(1), NonComparable(2)
+        # Construction must not raise TypeError
+        matcher = has_entries({k1: 1, k2: 2})
+        self.assertTrue(matcher.matches({k1: 1, k2: 2}))
+        self.assertFalse(matcher.matches({k1: 1, k2: 99}))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`has_entries()` raises `TypeError` at construction time when the supplied dictionary contains keys that do not support comparison (`__lt__`). This happens because `IsDictContainingEntries.__init__` stores entries as `sorted(value_matchers.items())`.

Real-world example (from issue #271): keys that are dataclass instances composed with an `Enum` — perfectly valid as dict keys (`__hash__` + `__eq__`), but not orderable.

## Root cause

```python
self.value_matchers = sorted(value_matchers.items())  # crashes if keys aren't comparable
```

The `sorted()` call was presumably added to produce deterministic output for `describe_to()`. Python 3.7+ already preserves dict insertion order, so the sort is redundant and the determinism concern is satisfied by the caller's dict.

## Fix

Replace `sorted()` with `list()` to preserve insertion order without imposing an ordering requirement on keys.

A regression test (`testHasEntriesWithNonSortableKeys`) is added to `isdict_containingentries_test.py`. All 454 existing tests continue to pass.

Fixes #271

---

This pull request was prepared with the assistance of AI, under my direction and review.